### PR TITLE
Updated golangci-lint-action timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
       uses: golangci/golangci-lint-action@v1
       with:
         version: v1.26
+        args: --timeout=20m
     - name: Parse release version and set REL_VERSION env var.
       run: python ./.github/scripts/get_release_version.py    
     - name: Setup node_module caching # this allows for re-using node_modules caching, making builds a bit faster.


### PR DESCRIPTION
* added --timeout=20m flag to increate timeout on golangci-lint-action timeout

closes #52 