### PR TITLE
Adding standalone support for configurations and components

### DIFF
--- a/cmd/webserver.go
+++ b/cmd/webserver.go
@@ -64,7 +64,7 @@ func RunWebServer() {
 
 	inst = instances.NewInstances(kubeClient)
 	comps = components.NewComponents(platform, daprClient)
-	configs = configurations.NewConfigurations(daprClient)
+	configs = configurations.NewConfigurations(platform, daprClient)
 
 	r := mux.NewRouter()
 	api := r.PathPrefix("/api/").Subrouter()
@@ -76,7 +76,6 @@ func RunWebServer() {
 	api.HandleFunc("/components", getComponentsHandler).Methods("GET")
 	api.HandleFunc("/components/{name}", getComponentHandler).Methods("GET")
 	api.HandleFunc("/deploymentconfiguration/{id}", getDeploymentConfigurationHandler).Methods("GET")
-	api.HandleFunc("/configurationsstatus", getConfigurationsStatusHandler).Methods("GET")
 	api.HandleFunc("/configurations", getConfigurationsHandler).Methods("GET")
 	api.HandleFunc("/configurations/{name}", getConfigurationHandler).Methods("GET")
 	api.HandleFunc("/environments", getEnvironmentsHandler).Methods("GET")
@@ -182,11 +181,6 @@ func getDeploymentConfigurationHandler(w http.ResponseWriter, r *http.Request) {
 	id := vars["id"]
 	details := inst.GetDeploymentConfiguration(id)
 	respondWithPlainString(w, 200, details)
-}
-
-func getConfigurationsStatusHandler(w http.ResponseWriter, r *http.Request) {
-	resp := configs.GetStatus()
-	respondWithJSON(w, 200, resp)
 }
 
 func getConfigurationsHandler(w http.ResponseWriter, r *http.Request) {

--- a/cmd/webserver.go
+++ b/cmd/webserver.go
@@ -54,13 +54,19 @@ var configs configurations.Configurations
 
 // RunWebServer starts the web server that serves the Dapr UI dashboard and the API
 func RunWebServer() {
+	platform := ""
 	kubeClient, daprClient, _ := kube.Clients()
+	if kubeClient != nil {
+		platform = "kubernetes"
+	} else {
+		platform = "standalone"
+	}
+
 	inst = instances.NewInstances(kubeClient)
-	comps = components.NewComponents(daprClient)
+	comps = components.NewComponents(platform, daprClient)
 	configs = configurations.NewConfigurations(daprClient)
 
 	r := mux.NewRouter()
-
 	api := r.PathPrefix("/api/").Subrouter()
 	api.HandleFunc("/features", getFeaturesHandler).Methods("GET")
 	api.HandleFunc("/instances", getInstancesHandler).Methods("GET")
@@ -68,7 +74,6 @@ func RunWebServer() {
 	api.HandleFunc("/instances/{id}", getInstanceHandler).Methods("GET")
 	api.HandleFunc("/instances/{id}/logs", getLogsHandler).Methods("GET")
 	api.HandleFunc("/components", getComponentsHandler).Methods("GET")
-	api.HandleFunc("/componentsstatus", getComponentsStatusHandler).Methods("GET")
 	api.HandleFunc("/components/{name}", getComponentHandler).Methods("GET")
 	api.HandleFunc("/deploymentconfiguration/{id}", getDeploymentConfigurationHandler).Methods("GET")
 	api.HandleFunc("/configurationsstatus", getConfigurationsStatusHandler).Methods("GET")
@@ -79,7 +84,6 @@ func RunWebServer() {
 	api.HandleFunc("/metadata/{id}", getMetadataHandler).Methods("GET")
 
 	spa := spaHandler{staticPath: "web/dist", indexPath: "index.html"}
-
 	r.PathPrefix("/").Handler(spa)
 
 	srv := &http.Server{
@@ -88,7 +92,6 @@ func RunWebServer() {
 		WriteTimeout: 15 * time.Second,
 		ReadTimeout:  15 * time.Second,
 	}
-
 	fmt.Println(fmt.Sprintf("Dapr Dashboard running on http://localhost:%v", port))
 	log.Fatal(srv.ListenAndServe())
 }
@@ -145,11 +148,6 @@ func getComponentHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	name := vars["name"]
 	resp := comps.GetComponent(name)
-	respondWithJSON(w, 200, resp)
-}
-
-func getComponentsStatusHandler(w http.ResponseWriter, r *http.Request) {
-	resp := comps.GetStatus()
 	respondWithJSON(w, 200, resp)
 }
 

--- a/cmd/webserver.go
+++ b/cmd/webserver.go
@@ -62,7 +62,7 @@ func RunWebServer() {
 		platform = "standalone"
 	}
 
-	inst = instances.NewInstances(kubeClient)
+	inst = instances.NewInstances(platform, kubeClient)
 	comps = components.NewComponents(platform, daprClient)
 	configs = configurations.NewConfigurations(platform, daprClient)
 
@@ -78,7 +78,7 @@ func RunWebServer() {
 	api.HandleFunc("/deploymentconfiguration/{id}", getDeploymentConfigurationHandler).Methods("GET")
 	api.HandleFunc("/configurations", getConfigurationsHandler).Methods("GET")
 	api.HandleFunc("/configurations/{name}", getConfigurationHandler).Methods("GET")
-	api.HandleFunc("/environments", getEnvironmentsHandler).Methods("GET")
+	api.HandleFunc("/platform", getPlatformHandler).Methods("GET")
 	api.HandleFunc("/controlplanestatus", getControlPlaneHandler).Methods("GET")
 	api.HandleFunc("/metadata/{id}", getMetadataHandler).Methods("GET")
 
@@ -158,15 +158,15 @@ func getFeaturesHandler(w http.ResponseWriter, r *http.Request) {
 	if configs.Supported() {
 		features = append(features, "configurations")
 	}
-	if inst.Supported() {
+	if inst.CheckPlatform() == "kubernetes" {
 		features = append(features, "status")
 	}
 	respondWithJSON(w, 200, features)
 }
 
-func getEnvironmentsHandler(w http.ResponseWriter, r *http.Request) {
-	resp := inst.CheckSupportedEnvironments()
-	respondWithJSON(w, 200, resp)
+func getPlatformHandler(w http.ResponseWriter, r *http.Request) {
+	resp := inst.CheckPlatform()
+	respondWithPlainString(w, 200, resp)
 }
 
 func getLogsHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -42,7 +42,7 @@ func NewComponents(platform string, daprClient scheme.Interface) Components {
 	return &c
 }
 
-// Component represents a platform-independent Dapr component
+// Component represents a Dapr component
 type Component struct {
 	Name     string      `json:"name"`
 	Kind     string      `json:"kind"`
@@ -97,6 +97,7 @@ func (c *components) getKubernetesComponents() []Component {
 	return out
 }
 
+// getStandaloneComponents returns the list of all locally-hosted Dapr components
 func (c *components) getStandaloneComponents() []Component {
 	componentsDirectory := standalone.DefaultComponentsDirPath()
 	standaloneComponents := []Component{}

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -1,87 +1,140 @@
 package components
 
 import (
+	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
 
+	"github.com/dapr/cli/pkg/standalone"
 	v1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dashboard/pkg/age"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // Components is an interface to interact with Dapr components
 type Components interface {
 	Supported() bool
-	GetComponents() []v1alpha1.Component
-	GetComponent(name string) v1alpha1.Component
-	GetStatus() []ComponentsOutput
+	GetComponents() []Component
+	GetComponent(name string) Component
 }
 
 type components struct {
-	daprClient scheme.Interface
-}
-
-// ComponentsOutput represent a Dapr component.
-type ComponentsOutput struct {
-	Name    string `json:"name"`
-	Type    string `json:"type"`
-	Age     string `json:"age"`
-	Created string `json:"created"`
+	platform        string
+	daprClient      scheme.Interface
+	getComponentsFn func() []Component
 }
 
 // NewComponents returns a new Components instance
-func NewComponents(daprClient scheme.Interface) Components {
-	return &components{
-		daprClient: daprClient,
+func NewComponents(platform string, daprClient scheme.Interface) Components {
+	c := components{}
+	c.platform = platform
+
+	if platform == "kubernetes" {
+		c.getComponentsFn = c.getKubernetesComponents
+		c.daprClient = daprClient
+	} else if platform == "standalone" {
+		c.getComponentsFn = c.getStandaloneComponents
 	}
+	return &c
 }
 
-// Supported checks whether or not the dapr client is available to access the components
+// Component represents a platform-independent Dapr component
+type Component struct {
+	Name     string      `json:"name"`
+	Kind     string      `json:"kind"`
+	Type     string      `json:"type"`
+	Created  string      `json:"created"`
+	Age      string      `json:"age"`
+	Scopes   []string    `json:"scopes"`
+	Manifest interface{} `json:"manifest"`
+}
+
+// Supported checks whether or not the supplied platform is able to access Dapr components
 func (c *components) Supported() bool {
-	return c.daprClient != nil
-}
-
-// GetComponents returns the list of all Dapr components
-func (c *components) GetComponents() []v1alpha1.Component {
-	comps, err := c.daprClient.ComponentsV1alpha1().Components(meta_v1.NamespaceDefault).List(meta_v1.ListOptions{})
-	if err != nil {
-		log.Println(err)
-		return []v1alpha1.Component{}
-	}
-	return comps.Items
+	return c.platform == "kubernetes" || c.platform == "standalone"
 }
 
 // GetComponent returns a specific component based on a supplied component name
-func (c *components) GetComponent(name string) v1alpha1.Component {
-	comps, err := c.daprClient.ComponentsV1alpha1().Components(meta_v1.NamespaceDefault).List(meta_v1.ListOptions{})
-	if err != nil {
-		log.Println(err)
-		return v1alpha1.Component{}
-	}
-	for _, c := range comps.Items {
-		if c.ObjectMeta.Name == name {
-			return c
+func (c *components) GetComponent(name string) Component {
+	comps := c.getComponentsFn()
+	for _, comp := range comps {
+		if comp.Name == name {
+			return comp
 		}
 	}
-	return v1alpha1.Component{}
+	return Component{}
 }
 
-// GetStatus returns returns a list of Dapr component statuses
-func (c *components) GetStatus() []ComponentsOutput {
-	comps, err := c.daprClient.ComponentsV1alpha1().Components(meta_v1.NamespaceDefault).List(meta_v1.ListOptions{})
+// GetComponent returns the result of the correct platform's getComponents function
+func (c *components) GetComponents() []Component {
+	return c.getComponentsFn()
+}
+
+// getKubernetesComponents returns the list of all Dapr components in a Kubernetes cluster
+func (c *components) getKubernetesComponents() []Component {
+	comps, err := c.daprClient.ComponentsV1alpha1().Components(metav1.NamespaceDefault).List(metav1.ListOptions{})
 	if err != nil {
 		log.Println(err)
-		return []ComponentsOutput{}
+		return []Component{}
 	}
+	out := []Component{}
+	for _, comp := range comps.Items {
+		newComponent := Component{
+			Name:     comp.Name,
+			Kind:     comp.Kind,
+			Type:     comp.Spec.Type,
+			Created:  comp.CreationTimestamp.Format("2006-01-02 15:04.05"),
+			Age:      age.GetAge(comp.CreationTimestamp.Time),
+			Scopes:   comp.Scopes,
+			Manifest: comp,
+		}
+		out = append(out, newComponent)
+	}
+	return out
+}
 
-	co := []ComponentsOutput{}
-	for _, c := range comps.Items {
-		co = append(co, ComponentsOutput{
-			Name:    c.GetName(),
-			Type:    c.Spec.Type,
-			Created: c.CreationTimestamp.Format("2006-01-02 15:04.05"),
-			Age:     age.GetAge(c.CreationTimestamp.Time),
-		})
+func (c *components) getStandaloneComponents() []Component {
+	componentsDirectory := standalone.DefaultComponentsDirPath()
+	standaloneComponents := []Component{}
+	err := filepath.Walk(componentsDirectory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			log.Printf("Failure accessing path %s: %v\n", path, err)
+			return err
+		}
+		if !info.IsDir() {
+			content, err := ioutil.ReadFile(path)
+			if err != nil {
+				log.Printf("Failure reading file %s: %v\n", path, err)
+				return err
+			}
+
+			comp := v1alpha1.Component{}
+			err = yaml.Unmarshal(content, &comp)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+
+			newComponent := Component{
+				Name:     comp.Name,
+				Kind:     comp.Kind,
+				Type:     comp.Spec.Type,
+				Created:  info.ModTime().Format("2006-01-02 15:04.05"),
+				Age:      age.GetAge(info.ModTime()),
+				Scopes:   comp.Scopes,
+				Manifest: string(content),
+			}
+			standaloneComponents = append(standaloneComponents, newComponent)
+			return nil
+		}
+		return nil
+	})
+	if err != nil {
+		log.Printf("error walking the path %q: %v\n", componentsDirectory, err)
+		return []Component{}
 	}
-	return co
+	return standaloneComponents
 }

--- a/pkg/configurations/configurations.go
+++ b/pkg/configurations/configurations.go
@@ -1,98 +1,145 @@
 package configurations
 
 import (
+	"fmt"
+	"io/ioutil"
 	"log"
+	"os"
 	"strconv"
 
+	"github.com/dapr/cli/pkg/standalone"
 	v1alpha1 "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 	scheme "github.com/dapr/dapr/pkg/client/clientset/versioned"
 	"github.com/dapr/dashboard/pkg/age"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
-// Configurations is an interface to interact with a Dapr configuration
+// Configurations is an interface to interact with Dapr configurations
 type Configurations interface {
 	Supported() bool
-	GetConfigurations() []v1alpha1.Configuration
-	GetConfiguration(name string) v1alpha1.Configuration
-	GetStatus() []ConfigurationsOutput
+	GetConfigurations() []Configuration
+	GetConfiguration(name string) Configuration
 }
 
 type configurations struct {
-	daprClient scheme.Interface
-}
-
-// ConfigurationsOutput represent a Dapr configuration
-type ConfigurationsOutput struct {
-	Name            string `csv:"Name"`
-	TracingEnabled  bool   `csv:"TRACING-ENABLED"`
-	MTLSEnabled     bool   `csv:"MTLS-ENABLED"`
-	WorkloadCertTTL string `csv:"MTLS-WORKLOAD-TTL"`
-	ClockSkew       string `csv:"MTLS-CLOCK-SKEW"`
-	Age             string `csv:"AGE"`
-	Created         string `csv:"CREATED"`
+	platform            string
+	daprClient          scheme.Interface
+	getConfigurationsFn func() []Configuration
 }
 
 // NewConfigurations returns a new Configurations instance
-func NewConfigurations(daprClient scheme.Interface) Configurations {
-	return &configurations{
-		daprClient: daprClient,
+func NewConfigurations(platform string, daprClient scheme.Interface) Configurations {
+	c := configurations{}
+	c.platform = platform
+
+	if platform == "kubernetes" {
+		c.getConfigurationsFn = c.getKubernetesConfigurations
+		c.daprClient = daprClient
+	} else if platform == "standalone" {
+		c.getConfigurationsFn = c.getStandaloneConfigurations
 	}
+	return &c
 }
 
-// Supported checks whether or not the dapr client is available to access the configurations
+// Configuration represents a Dapr configuration
+type Configuration struct {
+	Name            string      `json:"name"`
+	Kind            string      `json:"kind"`
+	Created         string      `json:"created"`
+	Age             string      `json:"age"`
+	TracingEnabled  bool        `json:"tracingEnabled"`
+	SamplingRate    string      `json:"samplingRate"`
+	MTLSEnabled     bool        `json:"mtlsEnabled"`
+	WorkloadCertTTL string      `json:"mtlsWorkloadTTL"`
+	ClockSkew       string      `json:"mtlsClockSkew"`
+	Manifest        interface{} `json:"manifest"`
+}
+
+// Supported checks whether or not the supplied platform is able to access Dapr configurations
 func (c *configurations) Supported() bool {
-	return c.daprClient != nil
+	return c.platform == "kubernetes" || c.platform == "standalone"
 }
 
-// GetConfigurations returns the list of all Dapr Configurations
-func (c *configurations) GetConfigurations() []v1alpha1.Configuration {
-	confs, err := c.daprClient.ConfigurationV1alpha1().Configurations(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
-	if err != nil {
-		log.Println(err)
-		return []v1alpha1.Configuration{}
-	}
-
-	return confs.Items
-}
-
-// GetConfiguration returns one Dapr configuration
-func (c *configurations) GetConfiguration(name string) v1alpha1.Configuration {
-	confs, err := c.daprClient.ConfigurationV1alpha1().Configurations(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
-	if err != nil {
-		log.Println(err)
-		return v1alpha1.Configuration{}
-	}
-
-	for _, c := range confs.Items {
-		if c.ObjectMeta.Name == name {
-			return c
+// GetConfiguration returns the Dapr configuration specified by name
+func (c *configurations) GetConfiguration(name string) Configuration {
+	confs := c.getConfigurationsFn()
+	for _, conf := range confs {
+		if conf.Name == name {
+			return conf
 		}
 	}
-	return v1alpha1.Configuration{}
+	return Configuration{}
 }
 
-// GetStatus returns the list of Dapr Configurations Statuses
-func (c *configurations) GetStatus() []ConfigurationsOutput {
+// GetConfigurations returns the result of the correct platform's getConfigurations function
+func (c *configurations) GetConfigurations() []Configuration {
+	return c.getConfigurationsFn()
+}
+
+// getKubernetesConfigurations returns the list of all Dapr Configurations in a Kubernetes cluster
+func (c *configurations) getKubernetesConfigurations() []Configuration {
 	confs, err := c.daprClient.ConfigurationV1alpha1().Configurations(meta_v1.NamespaceAll).List(meta_v1.ListOptions{})
 	if err != nil {
 		log.Println(err)
-		return []ConfigurationsOutput{}
+		return []Configuration{}
 	}
 
-	co := []ConfigurationsOutput{}
-	for _, c := range confs.Items {
-		co = append(co, ConfigurationsOutput{
-			TracingEnabled:  tracingEnabled(c.Spec.TracingSpec),
-			Name:            c.GetName(),
-			MTLSEnabled:     c.Spec.MTLSSpec.Enabled,
-			WorkloadCertTTL: c.Spec.MTLSSpec.WorkloadCertTTL,
-			ClockSkew:       c.Spec.MTLSSpec.AllowedClockSkew,
-			Created:         c.CreationTimestamp.Format("2006-01-02 15:04.05"),
-			Age:             age.GetAge(c.CreationTimestamp.Time),
-		})
+	out := []Configuration{}
+	for _, comp := range confs.Items {
+		newConfiguration := Configuration{
+			Name:            comp.Name,
+			Kind:            comp.Kind,
+			Created:         comp.CreationTimestamp.Format("2006-01-02 15:04.05"),
+			Age:             age.GetAge(comp.CreationTimestamp.Time),
+			TracingEnabled:  tracingEnabled(comp.Spec.TracingSpec),
+			SamplingRate:    comp.Spec.TracingSpec.SamplingRate,
+			MTLSEnabled:     comp.Spec.MTLSSpec.Enabled,
+			WorkloadCertTTL: comp.Spec.MTLSSpec.WorkloadCertTTL,
+			ClockSkew:       comp.Spec.MTLSSpec.AllowedClockSkew,
+			Manifest:        comp,
+		}
+		out = append(out, newConfiguration)
 	}
-	return co
+	return out
+}
+
+// getStandaloneConfigurations returns the list of Dapr Configurations Statuses
+func (c *configurations) getStandaloneConfigurations() []Configuration {
+	configurationFile := standalone.DefaultConfigFilePath()
+	content, err := ioutil.ReadFile(configurationFile)
+	if err != nil {
+		log.Printf("Failure reading file %s: %v\n", configurationFile, err)
+		return []Configuration{}
+	}
+
+	info, err := os.Stat(configurationFile)
+	if err != nil {
+		log.Printf("Failure reading file info from %s: %v\n", configurationFile, err)
+		return []Configuration{}
+	}
+
+	comp := v1alpha1.Configuration{}
+	err = yaml.Unmarshal(content, &comp)
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+
+	newConfiguration := Configuration{
+		Name:            comp.Name,
+		Kind:            comp.Kind,
+		Created:         info.ModTime().Format("2006-01-02 15:04.05"),
+		Age:             age.GetAge(info.ModTime()),
+		TracingEnabled:  tracingEnabled(comp.Spec.TracingSpec),
+		SamplingRate:    comp.Spec.TracingSpec.SamplingRate,
+		MTLSEnabled:     comp.Spec.MTLSSpec.Enabled,
+		WorkloadCertTTL: comp.Spec.MTLSSpec.WorkloadCertTTL,
+		ClockSkew:       comp.Spec.MTLSSpec.AllowedClockSkew,
+		Manifest:        string(content),
+	}
+
+	standaloneConfigurations := []Configuration{}
+	return append(standaloneConfigurations, newConfiguration)
 }
 
 // tracingEnabled checks if tracing is enabled for a configuration

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -434,6 +434,9 @@ func (i *instances) getStandaloneInstances() []Instance {
 		log.Println(err)
 	} else {
 		for _, o := range output {
+			if o.AppID == "" {
+				continue
+			}
 			list = append(list, Instance{
 				AppID:            o.AppID,
 				HTTPPort:         o.HTTPPort,

--- a/pkg/instances/instances.go
+++ b/pkg/instances/instances.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-
 	"time"
 
 	"github.com/dapr/cli/pkg/standalone"
@@ -22,6 +21,16 @@ import (
 	json_serializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
+)
+
+const (
+	daprEnabledAnnotation = "dapr.io/enabled"
+	daprIDAnnotation      = "dapr.io/id"
+	daprPortAnnotation    = "dapr.io/port"
+)
+
+var (
+	controlPlaneLabels = [...]string{"dapr-operator", "dapr-sentry", "dapr-placement", "dapr-sidecar-injector"}
 )
 
 // Instances is an interface to interact with running Dapr instances in Kubernetes or Standalone modes
@@ -35,56 +44,37 @@ type Instances interface {
 	GetControlPlaneStatus() []StatusOutput
 	GetMetadata(id string) MetadataOutput
 	GetActiveActorsCount(metadata MetadataOutput) []MetadataActiveActorsCount
-	CheckSupportedEnvironments() []string
+	CheckPlatform() string
 }
 
 type instances struct {
+	platform       string
 	kubeClient     *kubernetes.Clientset
 	getInstancesFn func() []Instance
 }
 
-const (
-	daprEnabledAnnotation = "dapr.io/enabled"
-	daprIDAnnotation      = "dapr.io/id"
-	daprPortAnnotation    = "dapr.io/port"
-)
-
-var (
-	controlPlaneLabels = [...]string{"dapr-operator", "dapr-sentry", "dapr-placement", "dapr-sidecar-injector"}
-)
-
-// NewInstances returns an Instances implementation
-func NewInstances(kubeClient *kubernetes.Clientset) Instances {
+// NewInstances returns an Instances instance
+func NewInstances(platform string, kubeClient *kubernetes.Clientset) Instances {
 	i := instances{}
+	i.platform = platform
 
-	if kubeClient != nil {
+	if i.platform == "kubernetes" {
 		i.getInstancesFn = i.getKubernetesInstances
 		i.kubeClient = kubeClient
-	} else {
+	} else if i.platform == "standalone" {
 		i.getInstancesFn = i.getStandaloneInstances
 	}
 	return &i
 }
 
-// Supported checks if the current kubernetes client is available
+// Supported checks if the current platform supports Dapr instances
 func (i *instances) Supported() bool {
-	return i.kubeClient != nil
+	return i.platform == "kubernetes" || i.platform == "standalone"
 }
 
-// GetInstances returns the result of the appropriate environment's GetInstance function
-func (i *instances) GetInstances() []Instance {
-	return i.getInstancesFn()
-}
-
-// CheckSupportedEnvironments checks for valid environments for Dapr applications to run in
-func (i *instances) CheckSupportedEnvironments() []string {
-	envs := make([]string, 2)
-	if i.kubeClient != nil {
-		envs = append(envs, "kubernetes")
-	} else {
-		envs = append(envs, "standalone")
-	}
-	return envs
+// CheckPlatform returns the current environment dashboard is running in
+func (i *instances) CheckPlatform() string {
+	return i.platform
 }
 
 // GetLogs returns a string of all logs for the given Dapr app id
@@ -372,6 +362,11 @@ func (i *instances) GetMetadata(id string) MetadataOutput {
 // GetActiveActorsCount returns the Actors slice of a MetadataOutput
 func (i *instances) GetActiveActorsCount(metadata MetadataOutput) []MetadataActiveActorsCount {
 	return metadata.Actors
+}
+
+// GetInstances returns the result of the appropriate environment's GetInstance function
+func (i *instances) GetInstances() []Instance {
+	return i.getInstancesFn()
 }
 
 // getKubernetesInstances gets the list of Dapr applications running in the Kubernetes environment

--- a/web/src/app/components/components.service.ts
+++ b/web/src/app/components/components.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import { DaprComponentStatus, DaprComponent } from '../types/types';
+import { DaprComponent } from '../types/types';
 
 @Injectable({
   providedIn: 'root',
@@ -16,9 +16,5 @@ export class ComponentsService {
 
   getComponent(name: string): Observable<DaprComponent> {
     return this.http.get<DaprComponent>('/api/components/' + name);
-  }
-
-  getComponentsStatus(): Observable<DaprComponentStatus[]> {
-    return this.http.get<DaprComponentStatus[]>('/api/componentsstatus');
   }
 }

--- a/web/src/app/configurations/configurations.service.ts
+++ b/web/src/app/configurations/configurations.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { DaprConfiguration, DaprConfigurationStatus } from '../types/types';
+import { DaprConfiguration } from '../types/types';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -16,9 +16,5 @@ export class ConfigurationsService {
 
   getConfiguration(name: string): Observable<DaprConfiguration> {
     return this.http.get<DaprConfiguration>('/api/configurations/' + name);
-  }
-
-  getConfigurationsStatus(): Observable<DaprConfigurationStatus[]> {
-    return this.http.get<DaprConfigurationStatus[]>('/api/configurationsstatus');
   }
 }

--- a/web/src/app/globals/globals.service.ts
+++ b/web/src/app/globals/globals.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +12,7 @@ export class GlobalsService {
 
   constructor(private http: HttpClient) { }
 
-  getSupportedEnvironments() {
-    return this.http.get('/api/environments');
+  getPlatform(): Observable<string> {
+    return this.http.get('/api/platform', { responseType: 'text' });
   }
 }

--- a/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.html
+++ b/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.html
@@ -1,4 +1,4 @@
-<h2 class="page-header-left" *ngIf="loadedConfiguration">Configuration: {{ configuration.metadata.name }}</h2>
+<h2 class="page-header-left" *ngIf="loadedConfiguration">Configuration: {{ configuration.name }}</h2>
 <mat-tab-group>
   <mat-tab label="Summary">
     <mat-card class="card-large mat-elevation-z8" *ngIf="loadedConfiguration">
@@ -9,33 +9,44 @@
         <table>
           <tbody>
             <tr>
+              <td class="table-label">Name</td>
+              <td class="table-data">{{ configuration.name }}</td>
+            </tr>
+            <tr>
               <td class="table-label">Kind</td>
               <td class="table-data">{{ configuration.kind }}</td>
             </tr>
             <tr>
-              <td class="table-label">Name</td>
-              <td class="table-data">{{ configuration.metadata.name }}</td>
-            </tr>
-            <tr>
-              <td class="table-label">Namespace</td>
-              <td class="table-data">{{ configuration.metadata.namespace }}</td>
-            </tr>
-            <tr>
               <td class="table-label">Created</td>
-              <td class="table-data">{{ configuration.metadata.creationTimestamp }}</td>
+              <td class="table-data">{{ configuration.created }}</td>
+            </tr>
+            <tr>
+              <td class="table-label">Age</td>
+              <td class="table-data">{{ configuration.age }}</td>
+            </tr>
+            <tr>
+              <td class="table-label">Tracing Enabled</td>
+              <td class="table-data">{{ configuration.tracingEnabled }}</td>
+            </tr>
+            <tr>
+              <td class="table-label">Sampling Rate</td>
+              <td class="table-data">{{ configuration.samplingRate }}</td>
+            </tr>
+            <tr>
+              <td class="table-label">MTLS Enabled</td>
+              <td class="table-data">{{ configuration.mtlsEnabled }}</td>
+            </tr>
+            <tr *ngIf="configuration.mtlsEnabled">
+              <td class="table-label">WorkloadCert TTL</td>
+              <td class="table-data">{{ configuration.mtlsWorkloadTTL }}</td>
+            </tr>
+            <tr *ngIf="configuration.mtlsEnabled">
+              <td class="table-label">Clock Skew</td>
+              <td class="table-data">{{ configuration.mtlsClockSkew }}</td>
             </tr>
           </tbody>
         </table>
       </mat-card-content>
-    </mat-card>
-  </mat-tab>
-  <mat-tab label="Metadata" *ngIf="loadedConfiguration">
-    <mat-card class="card-large mat-elevation-z8">
-      <mat-card-header>
-        <mat-card-title>Metadata</mat-card-title>
-      </mat-card-header>
-      <ng-monaco-editor style="height: 300px" modelUri="file:metadata.yaml" [options]="options" [(ngModel)]="configurationMetadata">
-      </ng-monaco-editor>
     </mat-card>
   </mat-tab>
   <mat-tab label="Configuration" *ngIf="loadedConfiguration">
@@ -43,7 +54,7 @@
       <mat-card-header>
         <mat-card-title>Deployment</mat-card-title>
       </mat-card-header>
-      <ng-monaco-editor style="height: 300px" modelUri="file:deployment.yaml" [options]="options" [(ngModel)]="configurationDeployment">
+      <ng-monaco-editor style="height: 300px" modelUri="file:manifest.yaml" [options]="options" [(ngModel)]="configurationManifest">
       </ng-monaco-editor>
     </mat-card>
   </mat-tab>

--- a/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.ts
+++ b/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.ts
@@ -15,8 +15,7 @@ export class ConfigurationDetailComponent implements OnInit {
 
   private name: string;
   public configuration: any;
-  public configurationMetadata: string | object;
-  public configurationDeployment: string | object;
+  public configurationManifest: string | object;
   public options: YamlViewerOptions;
   public loadedConfiguration: boolean;
 
@@ -47,8 +46,7 @@ export class ConfigurationDetailComponent implements OnInit {
   getConfiguration(name: string): void {
     this.configurationsService.getConfiguration(name).subscribe((data: DaprConfiguration) => {
       this.configuration = data;
-      this.configurationDeployment = yaml.safeDump(data);
-      this.configurationMetadata = yaml.safeDump(data.spec);
+      this.configurationManifest = yaml.safeDump(data.manifest);
       this.loadedConfiguration = true;
     });
   }

--- a/web/src/app/pages/configuration/configuration.component.html
+++ b/web/src/app/pages/configuration/configuration.component.html
@@ -2,31 +2,31 @@
 <table mat-table [dataSource]="config" class="table-large mat-elevation-z8">
   <ng-container matColumnDef="name">
     <th mat-header-cell *matHeaderCellDef>Name</th>
-    <td mat-cell *matCellDef="let item"><a routerLink="/configurations/{{item.Name}}">{{ item.Name }}</a></td>
+    <td mat-cell *matCellDef="let item"><a routerLink="/configurations/{{item.name}}">{{ item.name }}</a></td>
   </ng-container>
   <ng-container matColumnDef="tracing-enabled">
     <th mat-header-cell *matHeaderCellDef>Tracing Enabled</th>
-    <td mat-cell *matCellDef="let item">{{ item.TracingEnabled}}</td>
+    <td mat-cell *matCellDef="let item">{{ item.tracingEnabled}}</td>
   </ng-container>
   <ng-container matColumnDef="mtls-enabled">
     <th mat-header-cell *matHeaderCellDef>MTLS Enabled</th>
-    <td mat-cell *matCellDef="let item">{{ item.MTLSEnabled }}</td>
+    <td mat-cell *matCellDef="let item">{{ item.mtlsEnabled }}</td>
   </ng-container>
   <ng-container matColumnDef="mtls-workload-ttl">
     <th mat-header-cell *matHeaderCellDef>WorkloadCert TTL</th>
-    <td mat-cell *matCellDef="let item">{{ item.WorkloadCertTTL }}</td>
+    <td mat-cell *matCellDef="let item">{{ item.mtlsWorkloadTTL }}</td>
   </ng-container>
   <ng-container matColumnDef="mtls-clock-skew">
     <th mat-header-cell *matHeaderCellDef>Clock Skew</th>
-    <td mat-cell *matCellDef="let item">{{ item.ClockSkew }}</td>
+    <td mat-cell *matCellDef="let item">{{ item.mtlsClockSkew }}</td>
   </ng-container>
   <ng-container matColumnDef="age">
     <th mat-header-cell *matHeaderCellDef>Age</th>
-    <td mat-cell *matCellDef="let item">{{ item.Age }}</td>
+    <td mat-cell *matCellDef="let item">{{ item.age }}</td>
   </ng-container>
   <ng-container matColumnDef="created">
     <th mat-header-cell *matHeaderCellDef>Created</th>
-    <td mat-cell *matCellDef="let item">{{ item.Created }}</td>
+    <td mat-cell *matCellDef="let item">{{ item.created }}</td>
   </ng-container>
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>

--- a/web/src/app/pages/configuration/configuration.component.ts
+++ b/web/src/app/pages/configuration/configuration.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { ConfigurationsService } from 'src/app/configurations/configurations.service';
-import { DaprConfigurationStatus } from 'src/app/types/types';
+import { DaprConfiguration } from 'src/app/types/types';
+import { GlobalsService } from 'src/app/globals/globals.service';
 
 @Component({
   selector: 'app-configuration',
@@ -9,18 +10,28 @@ import { DaprConfigurationStatus } from 'src/app/types/types';
 })
 export class ConfigurationComponent implements OnInit {
 
-  public config: DaprConfigurationStatus[];
-  public displayedColumns: string[] = ['name', 'tracing-enabled', 'mtls-enabled', 'mtls-workload-ttl', 'mtls-clock-skew', 'age', 'created'];
+  public config: DaprConfiguration[];
+  public displayedColumns: string[];
+  public configurationsLoaded: boolean;
 
-  constructor(private configurationService: ConfigurationsService) { }
+  constructor(
+    private configurationService: ConfigurationsService,
+    public globalsService: GlobalsService,
+  ) { }
 
   ngOnInit(): void {
     this.getConfiguration();
+    if (this.globalsService.kubernetesEnabled) {
+      this.displayedColumns = ['name', 'tracing-enabled', 'mtls-enabled', 'mtls-workload-ttl', 'mtls-clock-skew', 'age', 'created'];
+    } else {
+      this.displayedColumns = ['name', 'tracing-enabled', 'mtls-enabled', 'age', 'created'];
+    }
   }
 
   getConfiguration(): void {
-    this.configurationService.getConfigurationsStatus().subscribe((data: DaprConfigurationStatus[]) => {
+    this.configurationService.getConfigurations().subscribe((data: DaprConfiguration[]) => {
       this.config = data;
+      this.configurationsLoaded = true;
     });
   }
 }

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.html
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.html
@@ -1,4 +1,4 @@
-<h2 class="page-header-left" *ngIf="loadedComponent">Component: {{ component.metadata.name }}</h2>
+<h2 class="page-header-left" *ngIf="loadedComponent">Component: {{ component.name }}</h2>
 <mat-tab-group>
   <mat-tab label="Summary">
     <mat-card class="card-large mat-elevation-z8" *ngIf="loadedComponent">
@@ -9,45 +9,40 @@
         <table>
           <tbody>
             <tr>
+              <td class="table-label">Name</td>
+              <td class="table-data">{{ component.name }}</td>
+            </tr>
+            <tr>
               <td class="table-label">Kind</td>
               <td class="table-data">{{ component.kind }}</td>
             </tr>
             <tr>
-              <td class="table-label">Name</td>
-              <td class="table-data">{{ component.metadata.name }}</td>
-            </tr>
-            <tr>
-              <td class="table-label">Namespace</td>
-              <td class="table-data">{{ component.metadata.namespace }}</td>
-            </tr>
-            <tr>
               <td class="table-label">Type</td>
-              <td class="table-data">{{ component.spec.type }}</td>
+              <td class="table-data">{{ component.type }}</td>
             </tr>
             <tr>
               <td class="table-label">Created</td>
-              <td class="table-data">{{ component.metadata.creationTimestamp }}</td>
+              <td class="table-data">{{ component.created }}</td>
+            </tr>
+            <tr>
+              <td class="table-label">Age</td>
+              <td class="table-data">{{ component.age }}</td>
+            </tr>
+            <tr *ngIf="component.scopes">
+              <td class="table-label">Scopes</td>
+              <td class="table-data">{{ component.scopes.join(", ") }}</td>
             </tr>
           </tbody>
         </table>
       </mat-card-content>
     </mat-card>
   </mat-tab>
-  <mat-tab label="Metadata" *ngIf="loadedComponent">
-    <mat-card class="card-large mat-elevation-z8">
-      <mat-card-header>
-        <mat-card-title>Metadata</mat-card-title>
-      </mat-card-header>
-      <ng-monaco-editor style="height: 300px" modelUri="file:metadata.yaml" [options]="options" [(ngModel)]="componentMetadata">
-      </ng-monaco-editor>
-    </mat-card>
-  </mat-tab>
   <mat-tab label="Configuration" *ngIf="loadedComponent">
     <mat-card class="card-large mat-elevation-z8">
       <mat-card-header>
-        <mat-card-title>Deployment</mat-card-title>
+        <mat-card-title>Manifest</mat-card-title>
       </mat-card-header>
-      <ng-monaco-editor style="height: 300px" modelUri="file:deployment.yaml" [options]="options" [(ngModel)]="componentDeployment">
+      <ng-monaco-editor style="height: 300px" modelUri="file:manifest.yaml" [options]="options" [(ngModel)]="componentManifest">
       </ng-monaco-editor>
     </mat-card>
   </mat-tab>

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
@@ -45,7 +45,6 @@ export class DaprComponentDetailComponent implements OnInit {
 
   getComponent(name: string): void {
     this.componentsService.getComponent(name).subscribe((data: DaprComponent) => {
-      console.log(data)
       this.component = data;
       this.componentManifest = yaml.safeDump(data.manifest);
       this.loadedComponent = true;

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
@@ -15,8 +15,7 @@ export class DaprComponentDetailComponent implements OnInit {
 
   private name: string;
   public component: any;
-  public componentMetadata: string | object;
-  public componentDeployment: string | object;
+  public componentManifest: string | object;
   public options: YamlViewerOptions;
   public loadedComponent: boolean;
 
@@ -46,9 +45,9 @@ export class DaprComponentDetailComponent implements OnInit {
 
   getComponent(name: string): void {
     this.componentsService.getComponent(name).subscribe((data: DaprComponent) => {
+      console.log(data)
       this.component = data;
-      this.componentDeployment = yaml.safeDump(data);
-      this.componentMetadata = yaml.safeDump(data.spec.metadata);
+      this.componentManifest = yaml.safeDump(data.manifest);
       this.loadedComponent = true;
     });
   }

--- a/web/src/app/pages/dapr-components/dapr-components.component.html
+++ b/web/src/app/pages/dapr-components/dapr-components.component.html
@@ -1,5 +1,5 @@
 <h2 class="page-header">Dapr Components</h2>
-<table mat-table [dataSource]="componentsStatus" class="table-large mat-elevation-z8">
+<table mat-table [dataSource]="components" class="table-large mat-elevation-z8">
   <ng-container matColumnDef="img">
     <th mat-header-cell *matHeaderCellDef></th>
     <td mat-cell *matCellDef="let item"><img src="{{item.img}}" class="component-img"></td>

--- a/web/src/app/pages/dapr-components/dapr-components.component.ts
+++ b/web/src/app/pages/dapr-components/dapr-components.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ComponentsService } from 'src/app/components/components.service';
-import { DaprComponentStatus } from 'src/app/types/types';
+import { DaprComponent } from 'src/app/types/types';
 
 @Component({
   selector: 'app-components',
@@ -9,8 +9,8 @@ import { DaprComponentStatus } from 'src/app/types/types';
 })
 export class DaprComponentsComponent implements OnInit {
 
-  public componentsStatus: DaprComponentStatus[];
-  public statusLoaded: boolean;
+  public components: DaprComponent[];
+  public componentsLoaded: boolean;
   public displayedColumns: string[] = ['img', 'name', 'status', 'age', 'created'];
 
   constructor(private componentsService: ComponentsService) { }
@@ -20,13 +20,12 @@ export class DaprComponentsComponent implements OnInit {
   }
 
   getComponents(): void {
-    this.statusLoaded = false;
-    this.componentsService.getComponentsStatus().subscribe((data: DaprComponentStatus[]) => {
-      this.componentsStatus = data;
-      this.componentsStatus.forEach(component => {
+    this.componentsService.getComponents().subscribe((data: DaprComponent[]) => {
+      this.components = data;
+      this.components.forEach(component => {
         component.img = this.getIconPath(component.type);
       });
-      this.statusLoaded = true;
+      this.componentsLoaded = true;
     });
   }
 
@@ -41,6 +40,8 @@ export class DaprComponentsComponent implements OnInit {
       return 'assets/images/pubsub.png';
     } else if (type.includes('exporters')) {
       return 'assets/images/tracing.png';
+    } else {
+      return 'assets/images/secretstores.png'
     }
   }
 }

--- a/web/src/app/pages/dapr-components/dapr-components.component.ts
+++ b/web/src/app/pages/dapr-components/dapr-components.component.ts
@@ -41,7 +41,7 @@ export class DaprComponentsComponent implements OnInit {
     } else if (type.includes('exporters')) {
       return 'assets/images/tracing.png';
     } else {
-      return 'assets/images/secretstores.png'
+      return 'assets/images/secretstores.png';
     }
   }
 }

--- a/web/src/app/pages/dashboard/dashboard.component.ts
+++ b/web/src/app/pages/dashboard/dashboard.component.ts
@@ -27,22 +27,9 @@ export class DashboardComponent implements OnInit, OnDestroy {
   ) { }
 
   ngOnInit(): void {
-    this.tableLoaded = false;
-    this.controlPlaneLoaded = false;
     this.getInstances();
     this.getControlPlaneData();
-    this.globals.getSupportedEnvironments().subscribe(data => {
-      const supportedEnvironments = data as Array<any>;
-      if (supportedEnvironments.includes('kubernetes')) {
-        this.globals.kubernetesEnabled = true;
-        this.displayedColumns = ['name', 'labels', 'status', 'age', 'selector'];
-      }
-      else if (supportedEnvironments.includes('standalone')) {
-        this.globals.standaloneEnabled = true;
-        this.displayedColumns = ['name', 'age', 'actions'];
-      }
-      this.tableLoaded = true;
-    });
+    this.checkPlatform();
 
     this.intervalHandler = setInterval(() => {
       this.getInstances();
@@ -54,8 +41,18 @@ export class DashboardComponent implements OnInit, OnDestroy {
     clearInterval(this.intervalHandler);
   }
 
-  checkEnvironment(): void {
-    this.globals.getSupportedEnvironments();
+  checkPlatform(): void {
+    this.globals.getPlatform().subscribe(platform => {
+      if (platform === 'kubernetes') {
+        this.globals.kubernetesEnabled = true;
+        this.displayedColumns = ['name', 'labels', 'status', 'age', 'selector'];
+      }
+      else if (platform === 'standalone') {
+        this.globals.standaloneEnabled = true;
+        this.displayedColumns = ['name', 'age', 'actions'];
+      }
+      this.tableLoaded = true;
+    });
   }
 
   getInstances(): void {

--- a/web/src/app/types/types.ts
+++ b/web/src/app/types/types.ts
@@ -57,19 +57,16 @@ export interface DaprComponent {
 
 // DaprConfiguration represents a Dapr configuration
 export interface DaprConfiguration {
-    metadata: any;
-    spec: any;
-}
-
-// DaprConfigurationStatus represents a Dapr configuration Status
-export interface DaprConfigurationStatus {
     name: string;
-    tracingEnabled: boolean;
-    mtlsEnabled: boolean;
-    workloadCertTTL: string;
-    clockSkew: string;
-    age: string;
+    kind: string;
     created: string;
+    age: string;
+    tracingEnabled: boolean;
+    samplingRate: string;
+    mtlsEnabled: boolean;
+    mtlsWorkloadTTL: string;
+    mtlsClockSkew: string;
+    manifest: any;
 }
 
 // YamlViewerOptions describes an options object for the NgMonacoEditor component

--- a/web/src/app/types/types.ts
+++ b/web/src/app/types/types.ts
@@ -45,19 +45,14 @@ export interface Log {
 
 // DaprComponent describes an Dapr component type
 export interface DaprComponent {
-    metadata: any;
-    spec: any;
-    auth: any;
-    scopes: any;
-}
-
-// DaprComponentStatus represents a Dapr component status
-export interface DaprComponentStatus {
-    img: string;
     name: string;
+    kind: string;
     type: string;
-    age: string;
     created: string;
+    age: string;
+    scopes: string[];
+    manifest: any;
+    img: string;
 }
 
 // DaprConfiguration represents a Dapr configuration


### PR DESCRIPTION
* Added configurations and components to standalone dashboard
* Changed platform detection logic by specifying exactly one platform in cmd/webserver.go
* Removed 'metadata' tab in components and configurations detail view
* Reorganized components and configurations typing - now uses custom type rather than kubernetes-specific type