### PR TITLE
Fix version setting.

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,9 +1,9 @@
 package version
 
-// Version is the current Dapr dashboard version
-var Version = "edge"
+// version is the current Dapr dashboard version
+var version = "edge"
 
 // GetVersion returns the current dashboard version
 func GetVersion() string {
-	return Version
+	return version
 }


### PR DESCRIPTION
Closes: #86 

Validated with the same build command displayed in GitHub actions:

```sh
CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 go build  -ldflags="-X github.com/dapr/dashboard/pkg/version.commit=3650307 -X github.com/dapr/dashboard/pkg/version.version=0.4.0 -s -w" -o release/darwin_amd64/dashboard ./main.go;
```