### PR TITLE
Distroless and nonroot docker image.

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
-FROM alpine:latest as alpine
+FROM gcr.io/distroless/static:nonroot
 
 ARG BIN_PATH
 EXPOSE 8080/tcp
+
 WORKDIR /app
 ADD $BIN_PATH/dashboard .
 ADD $BIN_PATH/web ./web


### PR DESCRIPTION
Runs dashboard with non-root and distroless image.

Closes: #119 