### PR TITLE
Several improvements to the dashboard layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Auto generated after a successful npm install
+web/src/environments/version.ts
+
 release/
 node_modules/
 web/npm-debug.log

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7266,6 +7266,25 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "git-describe": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/git-describe/-/git-describe-4.0.4.tgz",
+      "integrity": "sha512-L1X9OO1e4MusB4PzG9LXeXCQifRvyuoHTpuuZ521Qyxn/B0kWHWEOtsT4LsSfSNacZz0h4ZdYDsDG7f+SrA3hg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.11",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "glob": {
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",

--- a/web/package.json
+++ b/web/package.json
@@ -16,7 +16,8 @@
     "start:electron": "tsc main.ts && ng build && electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
-    "electron-postinstall": "electron-builder install-app-deps && ngcc"
+    "electron-postinstall": "electron-builder install-app-deps && ngcc",
+    "postinstall": "node scripts/version.js"
   },
   "dependencies": {
     "@angular/animations": "~9.1.11",
@@ -52,6 +53,7 @@
     "codelyzer": "^5.1.2",
     "electron": "^9.3.1",
     "electron-builder": "^22.7.0",
+    "git-describe": "^4.0.4",
     "husky": "^4.2.5",
     "jasmine-core": "~3.5.0",
     "jasmine-spec-reporter": "~4.2.1",

--- a/web/scripts/version.js
+++ b/web/scripts/version.js
@@ -1,0 +1,21 @@
+const { gitDescribeSync } = require('git-describe');
+const { version } = require('../package.json');
+const { resolve, relative } = require('path');
+const { writeFileSync } = require('fs-extra');
+
+const gitInfo = gitDescribeSync({
+    dirtyMark: false,
+    dirtySemver: false
+});
+
+gitInfo.version = version;
+
+const file = resolve(__dirname, '..', 'src', 'environments', 'version.ts');
+writeFileSync(file,
+    `// IMPORTANT: THIS FILE IS AUTO GENERATED! DO NOT MANUALLY EDIT OR CHECKIN!
+/* tslint:disable */
+export const VERSION = ${JSON.stringify(gitInfo, null, 4)};
+/* tslint:enable */
+`, { encoding: 'utf-8' });
+
+console.log(`Wrote version info ${gitInfo.raw} to ${relative(resolve(__dirname, '..'), file)}`);

--- a/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.html
+++ b/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.html
@@ -69,8 +69,8 @@
     </mat-card>
   </mat-tab>
   <mat-tab label="Configuration" *ngIf="loadedConfiguration">
-    <mat-card class="card-large mat-elevation-z8">
-      <pre style="font-family: Consolas, 'Courier New', monospace;"><code ngCodeColorize="yaml">{{ configurationManifest }}</code></pre>
+    <mat-card class="card-large mat-elevation-z8" [ngStyle]="{ 'background-color': isDarkTheme() ? '#1e1e1e' : '' }">
+      <app-editor [(model)]="configurationManifest"></app-editor>
     </mat-card>
   </mat-tab>
 </mat-tab-group>

--- a/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.ts
+++ b/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.ts
@@ -4,7 +4,7 @@ import { ConfigurationsService } from 'src/app/configurations/configurations.ser
 import { ActivatedRoute } from '@angular/router';
 import * as yaml from 'js-yaml';
 import { ThemeService } from 'src/app/theme/theme.service';
-import { YamlViewerOptions, Instance } from 'src/app/types/types';
+import { Instance } from 'src/app/types/types';
 import { GlobalsService } from 'src/app/globals/globals.service';
 
 @Component({
@@ -17,7 +17,6 @@ export class ConfigurationDetailComponent implements OnInit {
   private name: string;
   public configuration: any;
   public configurationManifest: string;
-  public options: YamlViewerOptions;
   public loadedConfiguration: boolean;
   public loadedApps: boolean;
   public configurationApps: Instance[];
@@ -35,23 +34,10 @@ export class ConfigurationDetailComponent implements OnInit {
     this.checkPlatform();
     this.getConfiguration(this.name);
     this.getConfigurationApps(this.name);
-    this.options = {
-      folding: true,
-      minimap: { enabled: true },
-      readOnly: false,
-      language: 'yaml',
-      theme: this.themeService.getTheme().includes('dark') ? 'vs-dark' : 'vs',
-    };
-    this.themeService.themeChanged.subscribe((newTheme: string) => {
-      this.options = {
-        ...this.options,
-        theme: newTheme.includes('dark') ? 'vs-dark' : 'vs',
-      };
-    });
   }
 
   checkPlatform(): void {
-    this.globals.getPlatform().subscribe(platform => { this.platform = platform; } );
+    this.globals.getPlatform().subscribe(platform => { this.platform = platform; });
   }
 
   getConfiguration(name: string): void {
@@ -67,5 +53,9 @@ export class ConfigurationDetailComponent implements OnInit {
       this.configurationApps = data;
       this.loadedApps = true;
     });
+  }
+
+  isDarkTheme(): boolean {
+    return this.themeService.isDarkTheme();
   }
 }

--- a/web/src/app/pages/configuration/configuration-detail/configuration-detail.module.ts
+++ b/web/src/app/pages/configuration/configuration-detail/configuration-detail.module.ts
@@ -2,21 +2,21 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ConfigurationDetailComponent } from './configuration-detail.component';
-import { MonacoEditorModule } from 'ng-monaco-editor';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
 import { MatListModule } from '@angular/material/list';
 import { RouterModule } from '@angular/router';
+import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
   imports: [
     CommonModule,
-    MonacoEditorModule,
     FormsModule,
     MatTabsModule,
     MatCardModule,
     MatListModule,
     RouterModule,
+    SharedModule
   ],
   declarations: [ConfigurationDetailComponent]
 })

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.html
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.html
@@ -38,8 +38,8 @@
     </mat-card>
   </mat-tab>
   <mat-tab label="Configuration" *ngIf="loadedComponent">
-    <mat-card class="card-large mat-elevation-z8">
-      <pre style="font-family: Consolas, 'Courier New', monospace;"><code ngCodeColorize="yaml">{{ componentManifest }}</code></pre>
+    <mat-card class="card-large mat-elevation-z8" [ngStyle]="{ 'background-color': isDarkTheme() ? '#1e1e1e' : '' }">
+      <app-editor [(model)]="componentManifest"></app-editor>
     </mat-card>
   </mat-tab>
 </mat-tab-group>

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
@@ -4,7 +4,6 @@ import { ComponentsService } from 'src/app/components/components.service';
 import { ActivatedRoute } from '@angular/router';
 import * as yaml from 'js-yaml';
 import { ThemeService } from 'src/app/theme/theme.service';
-import { YamlViewerOptions } from 'src/app/types/types';
 
 @Component({
   selector: 'app-dapr-component-detail',
@@ -16,7 +15,6 @@ export class DaprComponentDetailComponent implements OnInit {
   private name: string;
   public component: any;
   public componentManifest: string;
-  public options: YamlViewerOptions;
   public loadedComponent: boolean;
 
   constructor(
@@ -28,19 +26,6 @@ export class DaprComponentDetailComponent implements OnInit {
   ngOnInit(): void {
     this.name = this.route.snapshot.params.name;
     this.getComponent(this.name);
-    this.options = {
-      folding: true,
-      minimap: { enabled: true },
-      readOnly: false,
-      language: 'yaml',
-      theme: this.themeService.getTheme().includes('dark') ? 'vs-dark' : 'vs',
-    };
-    this.themeService.themeChanged.subscribe((newTheme: string) => {
-      this.options = {
-        ...this.options,
-        theme: newTheme.includes('dark') ? 'vs-dark' : 'vs',
-      };
-    });
   }
 
   getComponent(name: string): void {
@@ -49,5 +34,9 @@ export class DaprComponentDetailComponent implements OnInit {
       this.componentManifest = (typeof data.manifest === 'string') ? data.manifest : yaml.safeDump(data.manifest);
       this.loadedComponent = true;
     });
+  }
+
+  isDarkTheme(){
+    return this.themeService.isDarkTheme();
   }
 }

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.module.ts
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.module.ts
@@ -1,20 +1,20 @@
-import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { DaprComponentDetailComponent } from './dapr-component-detail.component';
-import { MonacoEditorModule } from 'ng-monaco-editor';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
+import { MatTabsModule } from '@angular/material/tabs';
+import { SharedModule } from '../../../shared/shared.module';
+import { DaprComponentDetailComponent } from './dapr-component-detail.component';
 
 @NgModule({
   imports: [
     CommonModule,
-    MonacoEditorModule,
     FormsModule,
     MatTabsModule,
     MatCardModule,
     MatTableModule,
+    SharedModule
   ],
   declarations: [
     DaprComponentDetailComponent

--- a/web/src/app/pages/dashboard/detail/detail.component.html
+++ b/web/src/app/pages/dashboard/detail/detail.component.html
@@ -94,8 +94,8 @@
     </mat-card>
   </mat-tab>
   <mat-tab *ngIf="platform === 'kubernetes'" label="Configuration">
-    <mat-card class="card-large mat-elevation-z8">
-      <pre style="font-family: Consolas, 'Courier New', monospace;"><code ngCodeColorize="yaml">{{ model }}</code></pre>
+    <mat-card class="card-large mat-elevation-z8" [ngStyle]="{ 'background-color': isDarkTheme() ? '#1e1e1e' : '' }">
+      <app-editor [(model)]="model"></app-editor>
     </mat-card>
   </mat-tab>
   <mat-tab label="Actors">

--- a/web/src/app/pages/dashboard/detail/detail.component.ts
+++ b/web/src/app/pages/dashboard/detail/detail.component.ts
@@ -5,7 +5,6 @@ import * as yaml from 'js-yaml';
 import { GlobalsService } from 'src/app/globals/globals.service';
 import { Metadata, Instance } from 'src/app/types/types';
 import { ThemeService } from 'src/app/theme/theme.service';
-import { YamlViewerOptions } from 'src/app/types/types';
 
 @Component({
   selector: 'app-detail',
@@ -23,7 +22,6 @@ export class DetailComponent implements OnInit, OnDestroy {
   public loadedInstance: boolean;
   public loadedMetadata: boolean;
   public metadata: Metadata;
-  public options: YamlViewerOptions;
   public platform: string;
   private intervalHandler;
 
@@ -38,19 +36,6 @@ export class DetailComponent implements OnInit, OnDestroy {
     this.id = this.route.snapshot.params.id;
     this.checkPlatform();
     this.loadData();
-    this.options = {
-      folding: true,
-      minimap: { enabled: true },
-      readOnly: false,
-      language: 'yaml',
-      theme: this.themeService.getTheme().includes('dark') ? 'vs-dark' : 'vs',
-    };
-    this.themeService.themeChanged.subscribe((newTheme: string) => {
-      this.options = {
-        ...this.options,
-        theme: newTheme.includes('dark') ? 'vs-dark' : 'vs',
-      };
-    });
 
     this.intervalHandler = setInterval(() => {
       this.getMetadata(this.id);
@@ -96,5 +81,9 @@ export class DetailComponent implements OnInit, OnDestroy {
     this.getConfiguration(this.id);
     this.getInstance(this.id);
     this.getMetadata(this.id);
+  }
+
+  isDarkTheme() {
+    return this.themeService.isDarkTheme();
   }
 }

--- a/web/src/app/pages/dashboard/detail/detail.module.ts
+++ b/web/src/app/pages/dashboard/detail/detail.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { DetailComponent } from '../detail/detail.component';
-import { MonacoEditorModule } from 'ng-monaco-editor';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
@@ -21,11 +20,11 @@ import { TimeSincePipe } from './logs/pipes/timeSince.pipe';
 import { MatNativeDateModule } from '@angular/material/core';
 import { TimePipe } from './logs/pipes/time.pipe';
 import { ISODatePipe } from './logs/pipes/isoDate.pipe';
+import { SharedModule } from '../../../shared/shared.module';
 
 @NgModule({
   imports: [
     CommonModule,
-    MonacoEditorModule,
     FormsModule,
     MatTabsModule,
     MatCardModule,
@@ -37,6 +36,7 @@ import { ISODatePipe } from './logs/pipes/isoDate.pipe';
     MatSelectModule,
     MatDatepickerModule,
     MatNativeDateModule,
+    SharedModule
   ],
   declarations: [
     DetailComponent,

--- a/web/src/app/pages/dialog-template.html
+++ b/web/src/app/pages/dialog-template.html
@@ -1,4 +1,16 @@
 <h1 mat-dialog-title>About</h1>
-<div mat-dialog-content>
-  Version: <strong>{{ data.version }}</strong>
-</div>
+<mat-dialog-content #info>
+  <p>
+    Dapr version: <strong>{{ data.version }}</strong>
+  </p>
+
+  <p>
+    Dapr Dashboard: <strong>{{ version.version }}</strong> (<i>{{ version.hash }}</i>)
+  </p>
+
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button mat-dialog-close>Close</button>
+  <button mat-button mat-dialog-close cdkFocusInitial (click)="copyInfo()">Copy info</button>
+</mat-dialog-actions>

--- a/web/src/app/pages/dialog-template.html
+++ b/web/src/app/pages/dialog-template.html
@@ -1,16 +1,35 @@
 <h1 mat-dialog-title>About</h1>
 <mat-dialog-content #info>
-  <p>
-    Dapr version: <strong>{{ data.version }}</strong>
-  </p>
 
-  <p>
-    Dapr Dashboard: <strong>{{ version.version }}</strong> (<i>{{ version.hash }}</i>)
-  </p>
+  <table>
+    <tr>
+      <td>
+        Dapr version
+      </td>
+      <td>
+        : <strong>{{ data.version }}</strong>
+        <button mat-icon-button aria-label="Copy" (click)="copyInfo(data.version)">
+          <mat-icon>content_copy</mat-icon>
+        </button>
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        Dapr Dashboard
+      </td>
+      <td>
+        : <strong>{{ version.version }}</strong> (<i>{{ version.hash }}</i>)
+        <button mat-icon-button aria-label="Copy" (click)="copyInfo(version.version + ' (' + version.hash + ')')">
+          <mat-icon>content_copy</mat-icon>
+        </button>
+      </td>
+    </tr>
+  </table>
 
 </mat-dialog-content>
 
 <mat-dialog-actions align="end">
   <button mat-button mat-dialog-close>Close</button>
-  <button mat-button mat-dialog-close cdkFocusInitial (click)="copyInfo()">Copy info</button>
+  <button mat-button mat-dialog-close cdkFocusInitial (click)="copyInfo()">Copy all</button>
 </mat-dialog-actions>

--- a/web/src/app/pages/pages.component.html
+++ b/web/src/app/pages/pages.component.html
@@ -38,17 +38,18 @@
       <a id="info-dialog" class="navigation-item" mat-list-item (click)="openDialog()">
         <mat-icon class="material-icons">info</mat-icon>
         <span class="navigation-item-label">Info</span>
-        <mat-divider class="navigation-divider"></mat-divider>
+
+        <mat-divider class="navigation-divider" *ngIf="globals.changesEnabledRoutes.includes(router.url)"></mat-divider>
       </a>
-      <mat-divider class="navigation-divider"></mat-divider>
-      <a fxLayout="row" fxLayoutAlign="space-around end" id="theme-selector" *ngIf="globals.changesEnabledRoutes.includes(router.url)" class="navigation-item"
-        mat-list-item (click)="onThemeChange()">
+      <a *ngIf="globals.changesEnabledRoutes.includes(router.url)" class="navigation-item" mat-list-item (click)="onThemeChange()">
         <mat-icon class="material-icons">{{ isLightMode() ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
         <span class="navigation-item-label">{{ isLightMode() ? 'Dark Theme' : 'Light Theme' }}</span>
       </a>
     </mat-nav-list>
   </mat-sidenav>
+
   <mat-sidenav-content [ngStyle]="{ 'margin-left.px': contentMargin }">
     <router-outlet></router-outlet>
   </mat-sidenav-content>
+
 </mat-sidenav-container>

--- a/web/src/app/pages/pages.component.html
+++ b/web/src/app/pages/pages.component.html
@@ -1,8 +1,11 @@
-<mat-toolbar class="pages-header mat-elevation-z5">
+<mat-toolbar class="mat-elevation-z5">
   <div id="imgWrapper">
     <img [src]="imgPath" id="header-image">
   </div>
   <h1 class="app-header">Dashboard</h1>
+
+  <span class="spacer"></span>
+
   <div id="scopeContainer" *ngIf="globals.changesEnabledRoutes.includes(router.url)">
     <mat-form-field id="scopeFormField">
       <mat-select (selectionChange)="onScopeChange()" [(ngModel)]="scopeValue" name="scope" placeholder="Scope">
@@ -13,6 +16,7 @@
     </mat-form-field>
   </div>
 </mat-toolbar>
+
 <mat-sidenav-container class="sidenav-container">
   <mat-sidenav #drawer class="sidenav" mode="side" [class.menu-open]="isMenuOpen" [class.menu-close]="!isMenuOpen"
     opened>
@@ -28,15 +32,19 @@
             class="navigation-item-label">{{ component.title }}</span>
         </a>
       </ng-container>
+
+      <span class="spacer"></span>
+
       <a id="info-dialog" class="navigation-item" mat-list-item (click)="openDialog()">
-        <mat-icon>info</mat-icon>
+        <mat-icon class="material-icons">info</mat-icon>
+        <span class="navigation-item-label">Info</span>
         <mat-divider class="navigation-divider"></mat-divider>
       </a>
       <mat-divider class="navigation-divider"></mat-divider>
       <a fxLayout="row" fxLayoutAlign="space-around end" id="theme-selector" *ngIf="globals.changesEnabledRoutes.includes(router.url)" class="navigation-item"
         mat-list-item (click)="onThemeChange()">
-        <mat-icon class="material-icons">{{ isLightMode ? 'nights_stay' : 'wb_sunny' }}</mat-icon><span
-          class="navigation-item-label">{{ isLightMode ? 'Dark Theme' : 'Light Theme' }}</span>
+        <mat-icon class="material-icons">{{ isLightMode ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
+        <span class="navigation-item-label">{{ isLightMode ? 'Dark Theme' : 'Light Theme' }}</span>
       </a>
     </mat-nav-list>
   </mat-sidenav>

--- a/web/src/app/pages/pages.component.html
+++ b/web/src/app/pages/pages.component.html
@@ -34,7 +34,7 @@
 
       <a mat-list-item (click)="openDialog()">
         <mat-icon matListIcon>info</mat-icon>
-        <span mat-line>Info</span>
+        <span mat-line>About</span>
       </a>
 
       <ng-container *ngIf="globals.changesEnabledRoutes.includes(router.url)" >

--- a/web/src/app/pages/pages.component.html
+++ b/web/src/app/pages/pages.component.html
@@ -1,12 +1,10 @@
 <mat-toolbar class="mat-elevation-z5">
-  <div id="imgWrapper">
-    <img [src]="isLightMode() ? '/assets/images/logo.svg' : '/assets/images/logo-white.svg'" id="header-image">
-  </div>
+  <img [src]="isLightMode() ? '/assets/images/logo.svg' : '/assets/images/logo-white.svg'" id="logo">
   <h1 class="app-header">Dashboard</h1>
 
   <span class="spacer"></span>
 
-  <div id="scopeContainer" *ngIf="globals.changesEnabledRoutes.includes(router.url)">
+  <div *ngIf="globals.changesEnabledRoutes.includes(router.url)">
     <mat-form-field id="scopeFormField">
       <mat-select (selectionChange)="onScopeChange()" [(ngModel)]="scopeValue" name="scope" placeholder="Scope">
         <mat-option *ngFor="let scope of scopes" [value]="scope">
@@ -18,33 +16,32 @@
 </mat-toolbar>
 
 <mat-sidenav-container class="sidenav-container">
-  <mat-sidenav #drawer class="sidenav" mode="side" [class.menu-open]="isMenuOpen" [class.menu-close]="!isMenuOpen"
-    opened>
-    <mat-nav-list class="navigation-list">
-      <a class="navigation-item" mat-list-item (click)="onDrawerToggle()">
-        <mat-icon class="material-icons">{{ isMenuOpen? 'chevron_left' : 'chevron_right' }}</mat-icon><span
-          class="navigation-item-label"></span>
-      </a>
+  <mat-sidenav #drawer class="sidenav" mode="side" [ngClass]="isMenuOpen ? 'menu-open' : 'menu-close'" opened>
+    <mat-nav-list>
+      <mat-list-item (click)="onDrawerToggle()">
+        <mat-icon>{{ isMenuOpen? 'chevron_left' : 'chevron_right' }}</mat-icon>
+        <span class="navigation-item-label"></span>
+      </mat-list-item>
       <ng-container *ngFor="let component of menu">
-        <mat-divider class="navigation-divider"></mat-divider>
-        <a class="navigation-item" mat-list-item [routerLink]="component.link" routerLinkActive="active">
-          <mat-icon class="material-icons">{{ component.icon }}</mat-icon><span
-            class="navigation-item-label">{{ component.title }}</span>
-        </a>
+        <mat-divider></mat-divider>
+        <mat-list-item [routerLink]="component.link" routerLinkActive="active">
+          <mat-icon>{{ component.icon }}</mat-icon>
+          <span class="navigation-item-label">{{ component.title }}</span>
+        </mat-list-item>
       </ng-container>
 
       <span class="spacer"></span>
 
-      <a id="info-dialog" class="navigation-item" mat-list-item (click)="openDialog()">
-        <mat-icon class="material-icons">info</mat-icon>
+      <mat-list-item (click)="openDialog()">
+        <mat-icon>info</mat-icon>
         <span class="navigation-item-label">Info</span>
 
-        <mat-divider class="navigation-divider" *ngIf="globals.changesEnabledRoutes.includes(router.url)"></mat-divider>
-      </a>
-      <a *ngIf="globals.changesEnabledRoutes.includes(router.url)" class="navigation-item" mat-list-item (click)="onThemeChange()">
-        <mat-icon class="material-icons">{{ isLightMode() ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
+        <mat-divider *ngIf="globals.changesEnabledRoutes.includes(router.url)"></mat-divider>
+      </mat-list-item>
+      <mat-list-item *ngIf="globals.changesEnabledRoutes.includes(router.url)" (click)="onThemeChange()">
+        <mat-icon>{{ isLightMode() ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
         <span class="navigation-item-label">{{ isLightMode() ? 'Dark Theme' : 'Light Theme' }}</span>
-      </a>
+      </mat-list-item>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/web/src/app/pages/pages.component.html
+++ b/web/src/app/pages/pages.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar class="mat-elevation-z5">
   <div id="imgWrapper">
-    <img [src]="imgPath" id="header-image">
+    <img [src]="isLightMode() ? '/assets/images/logo.svg' : '/assets/images/logo-white.svg'" id="header-image">
   </div>
   <h1 class="app-header">Dashboard</h1>
 
@@ -43,8 +43,8 @@
       <mat-divider class="navigation-divider"></mat-divider>
       <a fxLayout="row" fxLayoutAlign="space-around end" id="theme-selector" *ngIf="globals.changesEnabledRoutes.includes(router.url)" class="navigation-item"
         mat-list-item (click)="onThemeChange()">
-        <mat-icon class="material-icons">{{ isLightMode ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
-        <span class="navigation-item-label">{{ isLightMode ? 'Dark Theme' : 'Light Theme' }}</span>
+        <mat-icon class="material-icons">{{ isLightMode() ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
+        <span class="navigation-item-label">{{ isLightMode() ? 'Dark Theme' : 'Light Theme' }}</span>
       </a>
     </mat-nav-list>
   </mat-sidenav>

--- a/web/src/app/pages/pages.component.html
+++ b/web/src/app/pages/pages.component.html
@@ -15,37 +15,40 @@
   </div>
 </mat-toolbar>
 
-<mat-sidenav-container class="sidenav-container">
-  <mat-sidenav #drawer class="sidenav" mode="side" [ngClass]="isMenuOpen ? 'menu-open' : 'menu-close'" opened>
+<mat-sidenav-container>
+  <mat-sidenav #drawer mode="side" [ngClass]="isMenuOpen ? 'menu-open' : 'menu-close'" opened>
     <mat-nav-list>
-      <mat-list-item (click)="onDrawerToggle()">
-        <mat-icon>{{ isMenuOpen? 'chevron_left' : 'chevron_right' }}</mat-icon>
-        <span class="navigation-item-label"></span>
-      </mat-list-item>
+      <a mat-list-item (click)="onDrawerToggle()">
+        <mat-icon matListIcon>{{ isMenuOpen? 'chevron_left' : 'chevron_right' }}</mat-icon>
+        <span mat-line></span>
+      </a>
       <ng-container *ngFor="let component of menu">
         <mat-divider></mat-divider>
-        <mat-list-item [routerLink]="component.link" routerLinkActive="active">
-          <mat-icon>{{ component.icon }}</mat-icon>
-          <span class="navigation-item-label">{{ component.title }}</span>
-        </mat-list-item>
+        <a mat-list-item [routerLink]="component.link" routerLinkActive="active">
+          <mat-icon matListIcon>{{ component.icon }}</mat-icon>
+          <span mat-line>{{ component.title }}</span>
+        </a>
       </ng-container>
 
       <span class="spacer"></span>
 
-      <mat-list-item (click)="openDialog()">
-        <mat-icon>info</mat-icon>
-        <span class="navigation-item-label">Info</span>
+      <a mat-list-item (click)="openDialog()">
+        <mat-icon matListIcon>info</mat-icon>
+        <span mat-line>Info</span>
+      </a>
 
-        <mat-divider *ngIf="globals.changesEnabledRoutes.includes(router.url)"></mat-divider>
-      </mat-list-item>
-      <mat-list-item *ngIf="globals.changesEnabledRoutes.includes(router.url)" (click)="onThemeChange()">
-        <mat-icon>{{ isLightMode() ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
-        <span class="navigation-item-label">{{ isLightMode() ? 'Dark Theme' : 'Light Theme' }}</span>
-      </mat-list-item>
+      <ng-container *ngIf="globals.changesEnabledRoutes.includes(router.url)" >
+        <mat-divider></mat-divider>
+        <a mat-list-item (click)="onThemeChange()">
+          <mat-icon matListIcon>{{ isLightMode() ? 'nights_stay' : 'wb_sunny' }}</mat-icon>
+          <span mat-line>{{ isLightMode() ? 'Dark Theme' : 'Light Theme' }}</span>
+        </a>
+      </ng-container>
+      
     </mat-nav-list>
   </mat-sidenav>
 
-  <mat-sidenav-content [ngStyle]="{ 'margin-left.px': contentMargin }">
+  <mat-sidenav-content>
     <router-outlet></router-outlet>
   </mat-sidenav-content>
 

--- a/web/src/app/pages/pages.component.scss
+++ b/web/src/app/pages/pages.component.scss
@@ -2,22 +2,15 @@
 @use '../theme/tables.scss';
 @use '../theme/cards.scss';
 
-.navigation-item:hover {
-  cursor: pointer;
-}
-
-.mat-elevation-z5 {
-  position: relative;
-  z-index: 2;
-}
-
-.sidenav-container {
-  height: calc(100% - 4rem);
+mat-icon {
+  color: #888888;
 }
 
 mat-toolbar {
   display: flex;
   height: 4rem;
+  position: relative;
+  z-index: 2;
   
   #logo {
     width: 4rem;
@@ -33,10 +26,19 @@ mat-toolbar {
 
 mat-sidenav {
   overflow: hidden;
+  position: initial;
 }
 
-.spacer {
-  flex: 1 1 auto;
+mat-sidenav-container {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  height: calc(100% - 4rem);
+}
+
+mat-sidenav-content {
+  width: 100%;
+  margin-left: 0 !important;
 }
 
 mat-nav-list {
@@ -47,18 +49,16 @@ mat-nav-list {
   overflow: hidden;
 }
 
-.sidenav.menu-close {
-  width: 60px;
+.menu-close {
+  min-width: 64px;
+  max-width: 64px;
 }
 
-.sidenav.menu-open {
-  width: 200px;
+.menu-open {
+  min-width: 224px;
+  max-width: 224px;
 }
 
-mat-icon {
-  color: #888888;
-}
-
-.navigation-item-label {
-  padding-left: 20px;
+.spacer {
+  flex: 1 1 auto;
 }

--- a/web/src/app/pages/pages.component.scss
+++ b/web/src/app/pages/pages.component.scss
@@ -2,24 +2,6 @@
 @use '../theme/tables.scss';
 @use '../theme/cards.scss';
 
-#imgWrapper {
-  height: 100%;
-  width: 4rem;
-  text-align: center;
-  position: relative;
-  display: inline-block;
-  overflow: hidden;
-}
-
-#header-image {
-  height: 100%;
-  padding-left: 2rem;
-  position: absolute;
-  top: 50%;
-  left: 20%;
-  transform: translate(-50%, -50%);
-}
-
 .navigation-item:hover {
   cursor: pointer;
 }
@@ -36,6 +18,11 @@
 mat-toolbar {
   display: flex;
   height: 4rem;
+  
+  #logo {
+    width: 4rem;
+    padding-right: 0.5rem;
+  }
 
   #scopeFormField {
     padding: 0px 0 9px 0;

--- a/web/src/app/pages/pages.component.scss
+++ b/web/src/app/pages/pages.component.scss
@@ -2,14 +2,6 @@
 @use '../theme/tables.scss';
 @use '../theme/cards.scss';
 
-.pages-header {
-  height: 5%;
-}
-
-.mat-toolbar {
-  min-height: 4rem;
-}
-
 #imgWrapper {
   height: 100%;
   width: 4rem;
@@ -38,14 +30,32 @@
 }
 
 .sidenav-container {
-  height: 85%;
+  height: calc(100% - 4rem);
+}
+
+mat-toolbar {
+  display: flex;
+  height: 4rem;
+
+  #scopeFormField {
+    padding: 0px 0 9px 0;
+    height: 16px;
+    font-size: 1rem;
+  }
 }
 
 mat-sidenav {
   overflow: hidden;
 }
 
+.spacer {
+  flex: 1 1 auto;
+}
+
 mat-nav-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
   padding: 0;
   overflow: hidden;
 }
@@ -64,29 +74,4 @@ mat-icon {
 
 .navigation-item-label {
   padding-left: 20px;
-}
-
-#theme-selector {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-}
-
-#info-dialog {
-  position: absolute;
-  bottom: 48px;
-  left: 0;
-}
-
-#scopeContainer {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 200px;
-  height: 100%;
-}
-
-#scopeFormField {
-  position: absolute;
-  bottom: 0rem;
 }

--- a/web/src/app/pages/pages.component.ts
+++ b/web/src/app/pages/pages.component.ts
@@ -125,6 +125,15 @@ export class PagesComponent implements OnInit, OnDestroy {
 @Component({
   selector: 'app-about-dialog',
   templateUrl: 'dialog-template.html',
+  styles: [`
+    td button {
+      visibility: hidden;
+    }
+
+    td:hover button {
+      visibility: initial;
+    }
+  `]
 })
 export class AboutDialogComponent {
   @ViewChild('info', { static: true }) public info: ElementRef;
@@ -132,8 +141,8 @@ export class AboutDialogComponent {
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) { }
 
-  copyInfo() {
-    const data = this.info.nativeElement?.innerText || '';
-    navigator.clipboard.writeText(data.replace('\n\n', '\n'));
+  copyInfo(data?: string) {
+    const result = data || this.info.nativeElement?.innerText?.replace(/( )*content_copy( )*/g, '') || '';
+    navigator.clipboard.writeText(result.replace(/\n\n/g, '\n'));
   }
 }

--- a/web/src/app/pages/pages.component.ts
+++ b/web/src/app/pages/pages.component.ts
@@ -26,8 +26,6 @@ export class PagesComponent implements OnInit, OnDestroy {
   public menu: MenuItem[] = MENU_ITEMS;
   public isMenuOpen = false;
   public contentMargin = 60;
-  public isLightMode = true;
-  public imgPath: string;
   public themeSelectorEnabled: boolean;
   public scopeValue = 'All';
   public scopes: string[];
@@ -50,7 +48,6 @@ export class PagesComponent implements OnInit, OnDestroy {
     this.getFeatures();
     this.getScopes();
     this.componentCssClass = this.themeService.getTheme();
-    this.imgPath = '../../assets/images/logo.svg';
 
     this.intervalHandler = setInterval(() => {
       this.getScopes();
@@ -103,16 +100,10 @@ export class PagesComponent implements OnInit, OnDestroy {
   onThemeChange(): void {
     this.themeService.changeTheme();
     this.componentCssClass = this.themeService.getTheme();
-    this.isLightMode = !this.isLightMode;
     this.themeService.getThemes().forEach(theme => {
       this.overlayContainer.getContainerElement().classList.remove(theme);
     });
     this.overlayContainer.getContainerElement().classList.add(this.themeService.getTheme());
-    if (this.isLightMode) {
-      this.imgPath = '../../assets/images/logo.svg';
-    } else {
-      this.imgPath = '../../assets/images/logo-white.svg';
-    }
   }
 
   onScopeChange(): void {
@@ -127,6 +118,10 @@ export class PagesComponent implements OnInit, OnDestroy {
       }
     });
   }
+
+  isLightMode(): boolean {
+    return this.componentCssClass === "dashboard-light-theme";
+  }
 }
 
 @Component({
@@ -134,5 +129,5 @@ export class PagesComponent implements OnInit, OnDestroy {
   templateUrl: 'dialog-template.html',
 })
 export class AboutDialogComponent {
-  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {}
+  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) { }
 }

--- a/web/src/app/pages/pages.component.ts
+++ b/web/src/app/pages/pages.component.ts
@@ -1,13 +1,14 @@
-import { Component, ViewChild, OnInit, HostBinding, OnDestroy, Inject } from '@angular/core';
-import { MenuItem, MENU_ITEMS, COMPONENTS_MENU_ITEM, CONFIGURATIONS_MENU_ITEM, CONTROLPLANE_MENU_ITEM } from './pages-menu';
-import { FeaturesService } from 'src/app/features/features.service';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { Component, ElementRef, HostBinding, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatSidenav } from '@angular/material/sidenav';
+import { Router } from '@angular/router';
+import { FeaturesService } from 'src/app/features/features.service';
 import { GlobalsService } from 'src/app/globals/globals.service';
 import { ThemeService } from 'src/app/theme/theme.service';
-import { OverlayContainer } from '@angular/cdk/overlay';
-import { Router } from '@angular/router';
+import { VERSION } from '../../environments/version';
 import { ScopesService } from '../scopes/scopes.service';
-import { MatDialog, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { COMPONENTS_MENU_ITEM, CONFIGURATIONS_MENU_ITEM, CONTROLPLANE_MENU_ITEM, MenuItem, MENU_ITEMS } from './pages-menu';
 
 export interface DialogData {
   version: string;
@@ -112,7 +113,7 @@ export class PagesComponent implements OnInit, OnDestroy {
     this.dialog.open(AboutDialogComponent, {
       data: {
         version: this.version
-      }
+      } as DialogData
     });
   }
 
@@ -126,5 +127,13 @@ export class PagesComponent implements OnInit, OnDestroy {
   templateUrl: 'dialog-template.html',
 })
 export class AboutDialogComponent {
+  @ViewChild('info', { static: true }) public info: ElementRef;
+  public version = VERSION;
+
   constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) { }
+
+  copyInfo() {
+    const data = this.info.nativeElement?.innerText || '';
+    navigator.clipboard.writeText(data.replace('\n\n', '\n'));
+  }
 }

--- a/web/src/app/pages/pages.component.ts
+++ b/web/src/app/pages/pages.component.ts
@@ -120,7 +120,7 @@ export class PagesComponent implements OnInit, OnDestroy {
   }
 
   isLightMode(): boolean {
-    return this.componentCssClass === "dashboard-light-theme";
+    return this.componentCssClass === 'dashboard-light-theme';
   }
 }
 

--- a/web/src/app/pages/pages.component.ts
+++ b/web/src/app/pages/pages.component.ts
@@ -25,7 +25,6 @@ export class PagesComponent implements OnInit, OnDestroy {
   public drawer: MatSidenav;
   public menu: MenuItem[] = MENU_ITEMS;
   public isMenuOpen = false;
-  public contentMargin = 60;
   public themeSelectorEnabled: boolean;
   public scopeValue = 'All';
   public scopes: string[];
@@ -89,12 +88,6 @@ export class PagesComponent implements OnInit, OnDestroy {
 
   onDrawerToggle(): void {
     this.isMenuOpen = !this.isMenuOpen;
-    if (!this.isMenuOpen) {
-      this.contentMargin = 60;
-    }
-    else {
-      this.contentMargin = 240;
-    }
   }
 
   onThemeChange(): void {

--- a/web/src/app/pages/pages.component.ts
+++ b/web/src/app/pages/pages.component.ts
@@ -46,7 +46,7 @@ export class PagesComponent implements OnInit, OnDestroy {
     this.getVersion();
     this.getFeatures();
     this.getScopes();
-    this.componentCssClass = this.themeService.getTheme();
+    this.applyTheme();
 
     this.intervalHandler = setInterval(() => {
       this.getScopes();
@@ -92,6 +92,10 @@ export class PagesComponent implements OnInit, OnDestroy {
 
   onThemeChange(): void {
     this.themeService.changeTheme();
+    this.applyTheme();
+  }
+
+  private applyTheme(): void {
     this.componentCssClass = this.themeService.getTheme();
     this.themeService.getThemes().forEach(theme => {
       this.overlayContainer.getContainerElement().classList.remove(theme);

--- a/web/src/app/pages/pages.module.ts
+++ b/web/src/app/pages/pages.module.ts
@@ -43,5 +43,8 @@ import { MatDialogModule } from '@angular/material/dialog';
     PagesComponent,
     AboutDialogComponent
   ],
+  entryComponents: [
+    AboutDialogComponent
+  ]
 })
 export class PagesModule { }

--- a/web/src/app/pages/pages.module.ts
+++ b/web/src/app/pages/pages.module.ts
@@ -18,6 +18,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 import { MatSelectModule } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   imports: [
@@ -30,6 +31,7 @@ import { MatDialogModule } from '@angular/material/dialog';
     MatToolbarModule,
     MatIconModule,
     MatListModule,
+    MatButtonModule,
     ConfigurationModule,
     ControlPlaneModule,
     DaprComponentDetailModule,

--- a/web/src/app/shared/editor/editor.component.html
+++ b/web/src/app/shared/editor/editor.component.html
@@ -1,0 +1,5 @@
+<ng-monaco-editor
+  style="height: 300px"
+  [options]="options"
+  [(ngModel)]="model"
+  (ngModelChange)="modelChange.emit(model)"></ng-monaco-editor>

--- a/web/src/app/shared/editor/editor.component.ts
+++ b/web/src/app/shared/editor/editor.component.ts
@@ -1,0 +1,42 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { ThemeService } from '../../theme/theme.service';
+import { YamlViewerOptions } from '../../types/types';
+
+@Component({
+  selector: 'app-editor',
+  templateUrl: 'editor.component.html'
+})
+export class EditorComponent implements OnInit {
+
+  @Input() model: string;
+  @Output() modelChange = new EventEmitter<string>();
+
+  options: YamlViewerOptions;
+
+  constructor(
+    private themeService: ThemeService,
+  ) { }
+
+  ngOnInit() {
+    this.options = {
+      folding: true,
+      minimap: { enabled: true },
+      readOnly: true,
+      language: 'yaml',
+      contextmenu: false,
+      scrollBeyondLastLine: false,
+      lineNumbers: false as any,
+      theme: this.isDarkTheme() ? 'vs-dark' : 'vs'
+    };
+    this.themeService.themeChanged.subscribe((newTheme: string) => {
+      this.options = {
+        ...this.options,
+        theme: newTheme.includes('dark') ? 'vs-dark' : 'vs',
+      };
+    });
+  }
+
+  isDarkTheme(): boolean {
+    return this.themeService.getTheme().includes('dark');
+  }
+}

--- a/web/src/app/shared/shared.module.ts
+++ b/web/src/app/shared/shared.module.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MonacoEditorModule } from 'ng-monaco-editor';
+import { EditorComponent } from './editor/editor.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    MonacoEditorModule
+  ],
+  declarations: [
+    EditorComponent
+  ],
+  exports: [
+    EditorComponent
+  ]
+})
+export class SharedModule { }

--- a/web/src/app/theme/theme.service.ts
+++ b/web/src/app/theme/theme.service.ts
@@ -1,5 +1,7 @@
 import { Injectable, EventEmitter } from '@angular/core';
 
+const STORAGE_THEME_KEY = "preferred_dashboard_theme";
+
 @Injectable({
     providedIn: 'root'
 })
@@ -12,6 +14,13 @@ export class ThemeService {
     constructor() { }
 
     getTheme(): string {
+        const savedThemeItem = localStorage.getItem(STORAGE_THEME_KEY);
+        const savedThemeIndex = parseInt(savedThemeItem, 10);
+
+        if (!isNaN(savedThemeIndex) && savedThemeIndex < this.themes.length) {
+            this.themeIndex = savedThemeIndex;
+        }
+
         return this.themes[this.themeIndex];
     }
 
@@ -22,7 +31,9 @@ export class ThemeService {
     changeTheme() {
         this.themeIndex = this.themeIndex + 1;
         if (this.themeIndex >= this.themes.length) { this.themeIndex = 0; }
-        this.themeChanged.emit(this.getTheme());
+        this.themeChanged.emit(this.themes[this.themeIndex]);
+
+        localStorage.setItem(STORAGE_THEME_KEY, `${this.themeIndex}`);
     }
 }
 

--- a/web/src/app/theme/theme.service.ts
+++ b/web/src/app/theme/theme.service.ts
@@ -35,5 +35,9 @@ export class ThemeService {
 
         localStorage.setItem(STORAGE_THEME_KEY, `${this.themeIndex}`);
     }
+
+    isDarkTheme() {
+        return this.getTheme().includes('dark');
+    }
 }
 

--- a/web/src/app/theme/theme.service.ts
+++ b/web/src/app/theme/theme.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, EventEmitter } from '@angular/core';
 
-const STORAGE_THEME_KEY = "preferred_dashboard_theme";
+const STORAGE_THEME_KEY = 'preferred_dashboard_theme';
 
 @Injectable({
     providedIn: 'root'

--- a/web/src/app/types/types.ts
+++ b/web/src/app/types/types.ts
@@ -82,8 +82,11 @@ export interface DaprConfiguration {
 // YamlViewerOptions describes an options object for the NgMonacoEditor component
 export interface YamlViewerOptions {
     folding: boolean;
-    minimap: object;
-    readOnly: boolean;
+    minimap: { enabled: boolean };
+    readOnly?: boolean;
     language: string;
     theme: string;
+    contextmenu?: boolean;
+    scrollBeyondLastLine?: boolean;
+    lineNumbers?: boolean;
 }


### PR DESCRIPTION
Hi there!
I've made some changes to the dashboard to improve it a little bit.

In particular, this pull request contains changes as briefly described here:

 - Several improvements to the layout:
    - improved positioning of the `scope` select
    - dashboard will now fill the entire screen (both vertically and horizontally)
    - dashboard layout will now be more responsive (still not perfect on smartphones but at least now it can be used with tablets)
    - decluttered template code removing redundand classes and ids, useless styles, ...
    - sidenav and content placement are now automatically handled by the browser (no longer need to update the `margin-left` propery of the content section each time sidenav is toggled)
    - added a missing label in `about` button
 - Preferred theme is now persistent across page reloads.
    Each time a user changes theme color, his/her selection is stored in `localStorage`. When (s)he returns to the dashboard, we will use previously saved theme.
 - Showing Dapr Dashboard information in "About" popup. Those includes: 
    - Dapr version (e.g.: `edge`)
    - Dapr dashboard version (e.g.: `0.2.0`)
    - Dapr dashboard hash (e.g.: `g279393c`)
 - The "About" popup has now two buttons: "close" and "copy info". The latter one, as the name suggests, allows you to quickly copy information about your Dapr setup (currently dapr version, dapr dashboard version and hash)

Dapr dashboard details (version and hash) are generated using a custom NodeJS script stored in the `web/scripts` folder and automatically executed once npm packages are installed (through the `postinstall` hook).
This script will then get some info from Git, including the hash shown in the "About" popup. Dashboard version is instead being read from the `package.json` file located in the `web` folder. At this point a new file called `web/src/environments/version.ts` will be written and it will contain those details. Since it has been added to the `.gitignore`, it won't get accidentally committed.

The latter point should also address issue #148.

I'm also attaching a screenshot of the dashboard itself that, as you can see, is not changed very much since the majority of my changes are under the hood things.

![dashboard](https://user-images.githubusercontent.com/13736036/126039094-da7f1d0b-378e-44af-aa4b-cc9f79702648.png)

In case you have any questions/suggestions/doubts (or whatever), feel free to ping me :)

And, finally, have a nice day