### PR TITLE
Fixed an issue with YAML configuration loading

### DIFF
--- a/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.ts
+++ b/web/src/app/pages/configuration/configuration-detail/configuration-detail.component.ts
@@ -46,7 +46,7 @@ export class ConfigurationDetailComponent implements OnInit {
     this.configurationsService.getConfiguration(name).subscribe((data: DaprConfiguration) => {
       this.configuration = data;
       this.configurationManifest = (typeof data.manifest === 'string') ?
-        data.manifest : yaml.dump(data.manifest, { schema: yaml.FAILSAFE_SCHEMA });
+        data.manifest : yaml.dump(data.manifest);
       this.loadedConfiguration = true;
     });
   }

--- a/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
+++ b/web/src/app/pages/dapr-components/dapr-component-detail/dapr-component-detail.component.ts
@@ -34,7 +34,7 @@ export class DaprComponentDetailComponent implements OnInit {
     this.componentsService.getComponent(name).subscribe((data: DaprComponent) => {
       this.component = data;
       this.componentManifest = (typeof data.manifest === 'string') ?
-        data.manifest : yaml.dump(data.manifest, { schema: yaml.FAILSAFE_SCHEMA });
+        data.manifest : yaml.dump(data.manifest);
       this.loadedComponent = true;
     });
   }

--- a/web/src/app/pages/dashboard/detail/detail.component.ts
+++ b/web/src/app/pages/dashboard/detail/detail.component.ts
@@ -52,7 +52,7 @@ export class DetailComponent implements OnInit, OnDestroy {
     this.instanceService.getDeploymentConfiguration(id).subscribe((data: string) => {
       this.model = data;
       try {
-        this.modelYAML = yaml.load(data, { schema: yaml.FAILSAFE_SCHEMA });
+        this.modelYAML = yaml.load(data);
         this.annotations = Object.keys(this.modelYAML.metadata.annotations);
         this.loadedConfiguration = true;
       } catch (e) {


### PR DESCRIPTION
Hi there, it's still me ;)

This pull request aims at fixing an issue that was accidentally introduced during one of the previous refactorings. In particular, current version of the dashboard can't load the "configuration" page due to a YAML config file being validated against an incorrect schema.

This originated from an incorrect migration of each `yaml.safeDump(...)` calls to a `yaml.dump(..., { schema: yaml.FAILSAFE_SCHEMA })` one. With that schema, the yaml library expects no `null` values that now are used to signal something like an empty array

Note: this PR is independent from my other one currently open (#168) since this one is based on current version of master.

Closes: #171 
