### PR TITLE
Update fossa workflow's action version

### DIFF
--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -37,12 +37,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: "Run FOSSA Scan"
-        uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
 
       - name: "Run FOSSA Test"
-        uses: fossas/fossa-action@main # Use a specific version if locking is preferred
+        uses: fossas/fossa-action@v1.1.0 # Use a specific version if locking is preferred
         with:
           api-key: ${{ env.FOSSA_API_KEY }}
           run-tests: true


### PR DESCRIPTION
Signed-off-by: Shubham Sharma <shubhash@microsoft.com>

Due to a recent regression in FOSSA action's main branch, we are moving to the last working version.

Related to: https://github.com/dapr/dapr/issues/4523