### PR TITLE
Adds Helm chart for Dapr Dashboard only

### DIFF
--- a/.github/scripts/set_helm_dapr_version.sh
+++ b/.github/scripts/set_helm_dapr_version.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+replace_all() {
+  SUBSTRING=$1
+  CONTENT=$2
+  FILES=`grep -Hrl $SUBSTRING chart`
+  for file in $FILES; do
+    echo "Replacing \"$SUBSTRING\" with \"$CONTENT\" in $file ..."
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+      # Mac OSX
+      sed -i '' -e "s/$SUBSTRING/$CONTENT/" "$file"
+    else
+      # Linux
+      sed -e "s/$SUBSTRING/$CONTENT/" -i "$file"
+    fi
+  done
+}
+
+
+if [ -z $REL_VERSION ]; then
+  echo "REL_VERSION is not set. Exiting ..."
+  exit 1
+fi
+
+DAPR_VERSION_HELM="${REL_VERSION}"
+DAPR_VERSION_TAG="${REL_VERSION}"
+if [[ "$REL_VERSION" == "edge" || "$REL_VERSION" == "nightly"* ]]; then
+  DAPR_VERSION_HELM="0.0.0"
+fi
+
+replace_all "'edge'" "'$DAPR_VERSION_TAG'"
+replace_all "'0.0.0'" "'$DAPR_VERSION_HELM'"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -214,3 +214,115 @@ jobs:
         run: |
           echo "Build docker multiarch image manifest and push it"
           make docker-publish DAPR_REGISTRY=ghcr.io/${{ github.repository_owner }} DAPR_TAG=${{ env.REL_VERSION }}
+  helm-build:
+    name: Builds Helm chart
+    env:
+      HELM_PACKAGE_DIR: helm
+      HELMVER: v3.7.2
+      DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
+      ARTIFACT_DIR: ./helm_release
+      DAPR_VERSION_ARTIFACT: dapr_version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Helm ${{ env.HELMVER }}
+        uses: azure/setup-helm@v1
+        with:
+          version: ${{ env.HELMVER }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Parse release version and set REL_VERSION and LATEST_RELEASE
+        run: python ./.github/scripts/get_release_version.py ${{ github.event_name }}
+      - name: Set REPO_OWNER
+        shell: bash
+        run: |
+          REPO_OWNER=${{ github.repository_owner }}
+          # Lowercase the value
+          echo "REPO_OWNER=${REPO_OWNER,,}" >>${GITHUB_ENV}
+      - name: Update Helm chart files for release version ${{ env.REL_VERSION }}
+        run: ./.github/scripts/set_helm_dapr_version.sh
+      - name: Generate Helm chart manifest
+        if: env.DOCKER_REGISTRY != ''
+        env:
+          DAPR_REGISTRY: ${{ env.DOCKER_REGISTRY }}
+          DAPR_TAG: ${{ env.REL_VERSION }}
+        run: |
+          make manifest-gen
+        shell: bash
+      - name: Move Helm chart manifest to artifact
+        if: env.DOCKER_REGISTRY != ''
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}
+          mv ./release/install/dapr-dashboard.yaml ${{ env.ARTIFACT_DIR }}/dapr-dashboard.yaml
+      - name: Save release version
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          echo ${REL_VERSION} > ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/${{ env.DAPR_VERSION_ARTIFACT }}
+      - name: Package Helm chart
+        if: ${{ env.LATEST_RELEASE }} == "true" && env.DOCKER_REGISTRY != ''
+        env:
+          HELM_CHARTS_DIR: chart/dapr-dashboard
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          helm package ${{ env.HELM_CHARTS_DIR }} --destination ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      - name: Upload Helm charts package to artifacts
+        if: ${{ env.LATEST_RELEASE }} == "true" && env.DOCKER_REGISTRY != ''
+        uses: actions/upload-artifact@master
+        with:
+          name: dapr_helm_charts_package
+          path: ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+  # This job downloads the helm charts package artifact uploaded by the publish job,
+  # checks out the helm charts git hub pages repo and commits the latest version of
+  # helm charts package.
+  # This does not run on forks
+  helm-publish:
+    name: Publish Helm charts to Helm github pages repo
+    needs: helm-build
+    if: startswith(github.ref, 'refs/tags/v') && github.repository_owner == 'dapr'
+    env:
+      ARTIFACT_DIR: ./helm_release
+      DAPR_VERSION_ARTIFACT: dapr_version
+      HELM_PACKAGE_DIR: helm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Helm charts directory
+        run: |
+          mkdir -p ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      - name: download artifacts - dapr_helm_charts_package
+        uses: actions/download-artifact@master
+        with:
+          name: dapr_helm_charts_package
+          path: ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+      - name: Checkout Helm Charts Repo
+        uses: actions/checkout@v3
+        env:
+          DAPR_HELM_REPO: dapr/helm-charts
+          DAPR_HELM_REPO_CODE_PATH: helm-charts
+        with:
+          repository: ${{ env.DAPR_HELM_REPO }}
+          ref: refs/heads/master
+          token: ${{ secrets.DAPR_BOT_TOKEN }}
+          path: ${{ env.DAPR_HELM_REPO_CODE_PATH }}
+      - name: Upload helm charts to Helm Repo
+        env:
+          DAPR_HELM_REPO_CODE_PATH: helm-charts
+          DAPR_HELM_REPO: https://dapr.github.io/helm-charts/
+        run: |
+          daprVersion=`cat ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}/${{ env.DAPR_VERSION_ARTIFACT }}`
+          cd ${{ env.ARTIFACT_DIR }}/${{ env.HELM_PACKAGE_DIR }}
+          cp -r `ls -A | grep -v ${{ env.DAPR_VERSION_ARTIFACT }}` $GITHUB_WORKSPACE/${{ env.DAPR_HELM_REPO_CODE_PATH }}
+          cd $GITHUB_WORKSPACE/${{ env.DAPR_HELM_REPO_CODE_PATH }}
+          helm repo index --url ${{ env.DAPR_HELM_REPO }} --merge index.yaml .
+          git config --global user.email "daprweb@microsoft.com"
+          git config --global user.name "dapr-bot"
+          git add --all
+          # Check if the dapr-dashboard-${daprVersion}.tgz file is modified.
+          if git diff --name-only --staged | grep -q ${daprVersion}; then
+            # If it is, we update the Helm chart, since this is an intentional update.
+            git commit -m "Release - $daprVersion"
+            git push
+          else
+            # This check is here because the automation can fail, but the manual step is no longer required.
+            # If not, this update was accidentally triggered by tagging a release before updating the Helm chart.
+            echo "::error::There is no change for ${daprVersion} Helm chart. Did you forget to update the chart version before tagging?"
+            exit -1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ GIT_VERSION = $(shell git describe --always --abbrev=7 --dirty)
 # By default, disable CGO_ENABLED. See the details on https://golang.org/cmd/cgo
 CGO         ?= 0
 BINARIES    ?= dashboard
+HA_MODE     ?= false
 
 # Add latest tag if LATEST_RELEASE is true
 LATEST_RELEASE ?=
@@ -105,6 +106,17 @@ endif
 DAPR_ARTIFACTS := $(OUT_DIR)/artifacts
 DAPR_OUT_DIR := $(OUT_DIR)/$(GOOS)_$(GOARCH)
 DAPR_LINUX_OUT_DIR := $(OUT_DIR)/linux_$(GOARCH)
+
+# Helm template and install setting
+HELM:=helm
+HELM_RELEASE_NAME?=dapr-dashboard
+DAPR_NAMESPACE?=dapr-system
+DAPR_MTLS_ENABLED?=true
+HELM_CHART_ROOT:=./chart
+HELM_CHART_DIR:=$(HELM_CHART_ROOT)/dapr-dashboard
+HELM_OUT_DIR:=$(OUT_DIR)/install
+HELM_MANIFEST_FILE:=$(HELM_OUT_DIR)/$(HELM_RELEASE_NAME).yaml
+HELM_REGISTRY?=daprio.azurecr.io
 
 ################################################################################
 # Target: build                                                                #
@@ -214,3 +226,26 @@ run-backend-standalone:
 
 run-backend-kubernetes:
 	DAPR_DASHBOARD_KUBECONFIG=~/.kube/config $(DAPR_OUT_DIR)/dashboard$(BINARY_EXT)
+
+################################################################################
+# Target: manifest-gen                                                         #
+################################################################################
+
+# Generate helm chart manifest
+manifest-gen: dapr-dashboard.yaml
+
+dapr-dashboard.yaml: check-docker-env
+	$(info Generating helm manifest $(HELM_MANIFEST_FILE)...)
+	@mkdir -p $(HELM_OUT_DIR)
+	$(HELM) template \
+		--include-crds=true  --set ha.enabled=$(HA_MODE) --set-string tag=$(DAPR_TAG) --set-string registry=$(DAPR_REGISTRY) $(HELM_CHART_DIR) > $(HELM_MANIFEST_FILE)
+
+################################################################################
+# Target: upload-helmchart
+################################################################################
+
+# Upload helm charts to Helm Registry
+upload-helmchart:
+	export HELM_EXPERIMENTAL_OCI=1; \
+	$(HELM) chart save ${HELM_CHART_ROOT}/${HELM_RELEASE_NAME} ${HELM_REGISTRY}/${HELM}/${HELM_RELEASE_NAME}:${DAPR_VERSION}; \
+	$(HELM) chart push ${HELM_REGISTRY}/${HELM}/${HELM_RELEASE_NAME}:${DAPR_VERSION}

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ Dapr Dashboard provides information about Dapr applications, components, configu
 
 Dapr Dashboard comes pre-packaged with the Dapr CLI. To learn more about the dashboard command, use the CLI command `dapr dashboard -h`.
 
+If you want to install via Helm, run:
+```sh
+helm repo add dapr https://dapr.github.io/helm-charts/
+helm repo update
+helm install dapr-dashboard dapr/dapr-dashboard
+```
+
 #### Kubernetes
 Run `dapr dashboard -k`, or if you installed Dapr in a non-default namespace, `dapr dashboard -k -n <your-namespace>`.
 

--- a/chart/dapr-dashboard/.helmignore
+++ b/chart/dapr-dashboard/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/dapr-dashboard/Chart.yaml
+++ b/chart/dapr-dashboard/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: dapr-dashboard
+description: Dapr's dashboard.
+type: application
+version: '0.0.0'
+appVersion: '0.0.0'

--- a/chart/dapr-dashboard/README.md
+++ b/chart/dapr-dashboard/README.md
@@ -1,0 +1,33 @@
+## Dapr Dashboard options
+
+| Parameter                               | Description                                                                                                                                                            | Default            |
+|-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
+| `replicaCount`           | Number of replicas                                                                                                                                                     | `1`                |
+| `logLevel`               | service Log level                                                                                                                                                      | `info`             |
+| `image.registry`         | docker registry                                                                                                                                                        | `docker.io/daprio` |
+| `image.imagePullPolicy`                  | Global Control plane service imagePullPolicy                            | `IfNotPresent`          |
+| `image.imagePullSecrets` | docker images pull secrets for docker registry                                                                                                                         | `docker.io/daprio` |
+| `image.name`             | docker image name                                                                                                                                                      | `dashboard`        |
+| `image.tag`              | docker image tag                                                                                                                                                       | latest release         |
+| `serviceType`            | Type of [Kubernetes service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) to use for the Dapr Dashboard service | `ClusterIP`        |
+| `runAsNonRoot`           | Boolean value for `securityContext.runAsNonRoot`. You may have to set this to `false` when running in Minikube                                                         | `true`             |
+| `resources`              | Value of `resources` attribute. Can be used to set memory/cpu resources/limits. See the section "Resource configuration" above. Defaults to empty                      | `{}`               |
+| `ingress.enabled`        | Boolean value for enabling the creation of the ingress resource                                                                                                        | `false`            |
+| `ingress.className`      | ingress className of the ingress controller (e.g.nginx)                                                                                                                | ``                 |
+| `ingress.host`           | Fully qualified hostname of the dashboard URL (e.g `dashboard.dapr.local`) | ``                 |
+| `ingress.tls.enabled`    | If true, enables TLS on the ingress for the Dashboard                                                                                                                      | `false`            |
+| `ingress.tls.secretName` | Name of the Kubernetes secret containing the TLS certificate (key/certificate) for the Dashboard. Ignored if `dapr_dashboard.ingress.tls.enabled` is `false`. | ``                 |
+| `registry`                         | Docker image registry                                                   | `docker.io/daprio`      |
+| `tag`                              | Docker image version tag                                                | latest release          |
+| `logAsJson`                        | Json log format for control plane services                              | `false`                 |
+| `ha.enabled`                       | Highly Availability mode enabled for control plane                      | `false`                 |
+| `ha.replicaCount`                  | Number of replicas of control plane services in Highly Availability mode  | `3`                   |
+| `ha.disruption.minimumAvailable`   | Minimum amount of available instances for control plane. This can either be effective count or %. | ``             |
+| `ha.disruption.maximumUnavailable` | Maximum amount of instances that are allowed to be unavailable for control plane. This can either be effective count or %. | `25%`             |              |
+| `daprControlPlaneOs`               | Operating System for Dapr control plane                                 | `linux`                 |
+| `daprControlPlaneArch`             | CPU Architecture for Dapr control plane                                 | `amd64`                 |
+| `nodeSelector`                     | Pods will be scheduled onto a node node whose labels match the nodeSelector        | `{}`         |
+| `tolerations`                      | Pods will be allowed to schedule onto a node whose taints match the tolerations    | `{}`         |
+| `labels`                           | Custom pod labels                                                                  | `{}`         |
+| `k8sLabels`                        | Custom metadata labels                                                             | `{}`         |
+| `rbac.namespaced`                  | Removes cluster wide permissions where applicable  | `false` |

--- a/chart/dapr-dashboard/README.md
+++ b/chart/dapr-dashboard/README.md
@@ -1,4 +1,12 @@
-## Dapr Dashboard options
+## Install
+
+```sh
+helm repo add dapr https://dapr.github.io/helm-charts/
+helm repo update
+helm install dapr-dashboard dapr/dapr-dashboard
+```
+
+## Chart Options
 
 | Parameter                               | Description                                                                                                                                                            | Default            |
 |-----------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|

--- a/chart/dapr-dashboard/templates/_helpers.tpl
+++ b/chart/dapr-dashboard/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "dapr-dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "dapr-dashboard.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "dapr-dashboard.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "dapr-dashboard.labels" -}}
+helm.sh/chart: {{ include "dapr-dashboard.chart" . }}
+{{ include "dapr-dashboard.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "dapr-dashboard.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "dapr-dashboard.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dapr-dashboard.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dapr-dashboard.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/chart/dapr-dashboard/templates/dapr_dashboard_deployment.yaml
+++ b/chart/dapr-dashboard/templates/dapr_dashboard_deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dapr-dashboard
+  labels:
+    app: dapr-dashboard
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: dapr-dashboard
+  template:
+    metadata:
+      labels:
+        app: dapr-dashboard
+        {{- range $key, $value := .Values.k8sLabels }}
+        {{ $key }}: {{ tpl $value $ }}
+        {{- end }}
+        {{- with .Values.labels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: dapr-dashboard
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+             nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/os
+                    operator: In
+                    values:
+                    - {{ .Values.daprControlPlaneOs }}
+{{- if .Values.daprControlPlaneArch }}
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                    - {{ .Values.daprControlPlaneArch }}
+{{- end }}
+{{- if eq .Values.ha.enabled true }}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - dapr-dashboard
+            topologyKey: "kubernetes.io/hostname"
+{{- end }}
+      containers:
+      - name: dapr-dashboard
+        image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.imagePullPolicy }}
+{{- if eq .Values.daprControlPlaneOs "linux" }}
+        securityContext:
+          runAsNonRoot: {{ .Values.runAsNonRoot }}
+{{- end }}
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        ports:
+        - containerPort: 8080
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.image.imagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Values.image.imagePullSecrets }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}

--- a/chart/dapr-dashboard/templates/dapr_dashboard_ingress.yaml
+++ b/chart/dapr-dashboard/templates/dapr_dashboard_ingress.yaml
@@ -1,0 +1,33 @@
+{{- if eq .Values.ingress.enabled true }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: dapr-dashboard
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: dapr-dashboard
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className | quote }}
+  {{- end }}
+  {{- if eq .Values.ingress.tls.enabled true }}
+  tls:
+    - hosts:
+        - {{ .Values.ingress.host }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: dapr-dashboard
+                port:
+                  number: {{ .Values.ports.port }}
+{{- end }}

--- a/chart/dapr-dashboard/templates/dapr_dashboard_poddisruptionbudget.yaml
+++ b/chart/dapr-dashboard/templates/dapr_dashboard_poddisruptionbudget.yaml
@@ -1,0 +1,31 @@
+{{- if eq .Values.ha.enabled true }}
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
+apiVersion: policy/v1beta1
+{{- end }}
+kind: PodDisruptionBudget
+metadata:
+  name: dapr-dashboard-disruption-budget
+  labels:
+    app: dapr-dashboard
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+spec:
+{{- if .Values.ha.disruption.minimumAvailable }}
+  minAvailable: {{ .Values.ha.disruption.minimumAvailable }}
+{{- end }}
+{{- if .Values.ha.disruption.maximumUnavailable }}
+  maxUnavailable: {{ .Values.ha.disruption.maximumUnavailable }}
+{{- end }}
+  selector:
+    matchLabels:
+      app: dapr-dashboard
+      {{- range $key, $value := .Values.k8sLabels }}
+      {{ $key }}: {{ tpl $value $ }}
+      {{- end }}
+      {{- with .Values.labels }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
+{{- end }}

--- a/chart/dapr-dashboard/templates/dapr_dashboard_service.yaml
+++ b/chart/dapr-dashboard/templates/dapr_dashboard_service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: dapr-dashboard
+  labels:
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+  annotations:
+    {{- range $key, $val := .Values.serviceAnnotations }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
+spec:
+  selector:
+    app: dapr-dashboard
+  ports:
+  - protocol: TCP
+    port: {{ .Values.ports.port }}
+    targetPort: {{ .Values.ports.targetPort }}
+  type: {{ .Values.serviceType }}

--- a/chart/dapr-dashboard/templates/dapr_dashboard_serviceaccount.yaml
+++ b/chart/dapr-dashboard/templates/dapr_dashboard_serviceaccount.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dapr-dashboard
+  labels:
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+---
+{{- if eq .Values.rbac.namespaced true }}
+kind: Role
+{{- else }}
+kind: ClusterRole
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dapr-dashboard
+  labels:
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+rules:
+- apiGroups: [""]
+  resources: ["pods", "pods/log", "namespaces"]
+  verbs: ["get", "list"]
+- apiGroups: ["apps"]
+  resources: ["deployments", "components", "configurations"]
+  verbs: ["get", "list"]
+- apiGroups: ["dapr.io"]
+  resources: ["components", "configurations"]
+  verbs: ["get", "list"]
+---
+{{- if eq .Values.rbac.namespaced true }}
+kind: RoleBinding
+{{- else }}
+kind: ClusterRoleBinding
+{{- end }}
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: dapr-dashboard
+  labels:
+    {{- range $key, $value := .Values.k8sLabels }}
+    {{ $key }}: {{ tpl $value $ }}
+    {{- end }}
+subjects:
+- kind: ServiceAccount
+  name: dapr-dashboard
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+{{- if eq .Values.rbac.namespaced true }}
+  kind: Role
+{{- else }}
+  kind: ClusterRole
+{{- end }}
+  name: dapr-dashboard

--- a/chart/dapr-dashboard/values.yaml
+++ b/chart/dapr-dashboard/values.yaml
@@ -1,0 +1,51 @@
+replicaCount: 1
+logLevel: info
+component: dashboard
+
+image:
+  registry: docker.io/daprio
+  name: dashboard
+  tag: 'edge'
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: ""
+
+nameOverride: ""
+fullnameOverride: ""
+
+ports:
+  protocol: TCP
+  port: 8080
+  targetPort: 8080
+
+ingress:
+  enabled: false
+  className:
+  host:
+  tls:
+    enabled: false
+    secretName:
+
+runAsNonRoot: true
+serviceType: ClusterIP
+resources: {}
+serviceAnnotations: {}
+rbac:
+  namespaced: false
+ha:
+  enabled: false
+  replicaCount: 3
+  disruption:
+    minimumAvailable: ""
+    maximumUnavailable: "25%"
+
+nodeSelector: {}
+tolerations: []
+
+daprControlPlaneOs: linux
+labels: {}
+
+k8sLabels:
+  app.kubernetes.io/name: "dapr-dashboard"
+  app.kubernetes.io/version: "{{ .Values.image.tag }}"
+  app.kubernetes.io/part-of: "dapr"
+  app.kubernetes.io/managed-by: "helm"


### PR DESCRIPTION
Test locally with `helm install dapr-dashboard ./chart/dapr-dashboard`

After next release: `helm install dapr-dashboard dapr/dapr-dashboard`

First part of: https://github.com/dapr/dapr/issues/4724